### PR TITLE
Add network speed live update settings

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.17.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
     implementation("io.github.d4viddf:hyperisland_kit:0.4.3")
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,14 +1,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
+    />
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"
     />
     <uses-permission
         android:name="android.permission.POST_PROMOTED_NOTIFICATIONS"
     />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:label="LiveBridge"
@@ -56,6 +61,18 @@
         />
 
         <service
+            android:name=".liveupdate.networkspeed.NetworkSpeedForegroundService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="specialUse|dataSync"
+        >
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="network_speed_monitor"
+            />
+        </service>
+
+        <service
             android:name=".liveupdate.LiveBridgeTileService"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             android:exported="true"
@@ -73,6 +90,17 @@
             android:name=".liveupdate.OtpCopyReceiver"
             android:exported="false"
         />
+
+        <receiver
+            android:name=".liveupdate.networkspeed.NetworkSpeedBootReceiver"
+            android:enabled="true"
+            android:exported="true"
+        >
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
 
         <meta-data android:name="flutterEmbedding" android:value="2" />
     </application>

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/MainActivity.kt
@@ -40,6 +40,7 @@ import com.appsfolder.livebridge.liveupdate.LiveParserDictionary
 import com.appsfolder.livebridge.liveupdate.LiveParserDictionaryLoader
 import com.appsfolder.livebridge.liveupdate.LiveUpdateNotifier
 import com.appsfolder.livebridge.liveupdate.LiveUpdateNotificationListenerService
+import com.appsfolder.livebridge.liveupdate.networkspeed.NetworkSpeedController
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
@@ -69,6 +70,7 @@ class MainActivity : FlutterActivity() {
         val prefs = ConverterPrefs(applicationContext)
         initializeKeepAliveDefaultIfNeeded(prefs)
         syncKeepAliveForegroundService(prefs)
+        NetworkSpeedController.sync(applicationContext, prefs)
         clearDynamicLauncherShortcuts()
         LiveBridgeTileService.requestStateSync(applicationContext)
     }
@@ -81,6 +83,9 @@ class MainActivity : FlutterActivity() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (requestCode == REQUEST_POST_NOTIFICATIONS) {
             val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+            if (granted) {
+                NetworkSpeedController.sync(applicationContext, ConverterPrefs(applicationContext))
+            }
             notificationPermissionResult?.success(granted)
             notificationPermissionResult = null
         }
@@ -97,6 +102,7 @@ class MainActivity : FlutterActivity() {
             "getPixelJokeBypassEnabled" -> res.success(prefs.getPixelJokeBypassEnabled())
             "setPixelJokeBypassEnabled" -> {
                 prefs.setPixelJokeBypassEnabled(call.argument<Boolean>("value") ?: false)
+                NetworkSpeedController.sync(applicationContext, prefs)
                 res.success(true)
             }
 
@@ -239,6 +245,43 @@ class MainActivity : FlutterActivity() {
             "getTextProgressEnabled" -> res.success(prefs.getTextProgressEnabled())
             "setTextProgressEnabled" -> {
                 prefs.setTextProgressEnabled(call.argument<Boolean>("value") ?: true)
+                res.success(true)
+            }
+
+            "getNetworkSpeedSettings" -> res.success(prefs.getNetworkSpeedSettings().toMap())
+            "setNetworkSpeedEnabled" -> {
+                prefs.setNetworkSpeedEnabled(call.argument<Boolean>("value") ?: false)
+                NetworkSpeedController.sync(applicationContext, prefs)
+                res.success(true)
+            }
+            "setNetworkSpeedDisplayMode" -> {
+                prefs.setNetworkSpeedDisplayMode(call.argument<String>("value"))
+                NetworkSpeedController.sync(applicationContext, prefs)
+                res.success(true)
+            }
+            "setNetworkSpeedUploadPrefix" -> {
+                prefs.setNetworkSpeedUploadPrefix(call.argument<String>("value"))
+                NetworkSpeedController.sync(applicationContext, prefs)
+                res.success(true)
+            }
+            "setNetworkSpeedDownloadPrefix" -> {
+                prefs.setNetworkSpeedDownloadPrefix(call.argument<String>("value"))
+                NetworkSpeedController.sync(applicationContext, prefs)
+                res.success(true)
+            }
+            "setNetworkSpeedPrioritizeUploadSpeed" -> {
+                prefs.setNetworkSpeedPrioritizeUploadSpeed(call.argument<Boolean>("value") ?: true)
+                NetworkSpeedController.sync(applicationContext, prefs)
+                res.success(true)
+            }
+            "setNetworkSpeedChipBackgroundDisabled" -> {
+                prefs.setNetworkSpeedChipBackgroundDisabled(call.argument<Boolean>("value") ?: false)
+                NetworkSpeedController.sync(applicationContext, prefs)
+                res.success(true)
+            }
+            "setNetworkSpeedUnit" -> {
+                prefs.setNetworkSpeedUnit(call.argument<String>("value"))
+                NetworkSpeedController.sync(applicationContext, prefs)
                 res.success(true)
             }
 
@@ -462,6 +505,7 @@ class MainActivity : FlutterActivity() {
 
     private fun applyConverterEnabled(prefs: ConverterPrefs, value: Boolean) {
         prefs.setConverterEnabled(value)
+        NetworkSpeedController.sync(applicationContext, prefs)
         if (!value) {
             LiveUpdateNotifier.clearRuntimeState()
             NotificationManagerCompat.from(applicationContext).cancelAll()

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/ConverterPrefs.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/ConverterPrefs.kt
@@ -1,6 +1,9 @@
 package com.appsfolder.livebridge.liveupdate
 
 import android.content.Context
+import com.appsfolder.livebridge.liveupdate.networkspeed.NetworkSpeedDisplayMode
+import com.appsfolder.livebridge.liveupdate.networkspeed.NetworkSpeedSettings
+import com.appsfolder.livebridge.liveupdate.networkspeed.NetworkSpeedUnit
 import java.util.Locale
 
 class ConverterPrefs(context: Context) {
@@ -202,6 +205,96 @@ class ConverterPrefs(context: Context) {
         prefs.edit().putBoolean(KEY_SMART_VPN_ENABLED, value).apply()
     }
 
+    fun getNetworkSpeedEnabled(): Boolean {
+        return prefs.getBoolean(KEY_NETWORK_SPEED_ENABLED, false)
+    }
+
+    fun setNetworkSpeedEnabled(value: Boolean) {
+        prefs.edit().putBoolean(KEY_NETWORK_SPEED_ENABLED, value).apply()
+    }
+
+    fun getNetworkSpeedDisplayMode(): NetworkSpeedDisplayMode {
+        val raw = prefs.getString(KEY_NETWORK_SPEED_DISPLAY_MODE, NetworkSpeedDisplayMode.TOTAL.id)
+        return NetworkSpeedDisplayMode.from(raw)
+    }
+
+    fun setNetworkSpeedDisplayMode(value: String?) {
+        val displayMode = NetworkSpeedDisplayMode.from(value)
+        prefs.edit().putString(KEY_NETWORK_SPEED_DISPLAY_MODE, displayMode.id).apply()
+    }
+
+    fun getNetworkSpeedUploadPrefix(): String {
+        val value = prefs.getString(
+            KEY_NETWORK_SPEED_UPLOAD_PREFIX,
+            NetworkSpeedSettings.DEFAULT_UPLOAD_PREFIX
+        )
+        return value ?: NetworkSpeedSettings.DEFAULT_UPLOAD_PREFIX
+    }
+
+    fun setNetworkSpeedUploadPrefix(value: String?) {
+        prefs.edit()
+            .putString(
+                KEY_NETWORK_SPEED_UPLOAD_PREFIX,
+                value ?: NetworkSpeedSettings.DEFAULT_UPLOAD_PREFIX
+            )
+            .apply()
+    }
+
+    fun getNetworkSpeedDownloadPrefix(): String {
+        val value = prefs.getString(
+            KEY_NETWORK_SPEED_DOWNLOAD_PREFIX,
+            NetworkSpeedSettings.DEFAULT_DOWNLOAD_PREFIX
+        )
+        return value ?: NetworkSpeedSettings.DEFAULT_DOWNLOAD_PREFIX
+    }
+
+    fun setNetworkSpeedDownloadPrefix(value: String?) {
+        prefs.edit()
+            .putString(
+                KEY_NETWORK_SPEED_DOWNLOAD_PREFIX,
+                value ?: NetworkSpeedSettings.DEFAULT_DOWNLOAD_PREFIX
+            )
+            .apply()
+    }
+
+    fun getNetworkSpeedPrioritizeUploadSpeed(): Boolean {
+        return prefs.getBoolean(KEY_NETWORK_SPEED_PRIORITIZE_UPLOAD, true)
+    }
+
+    fun setNetworkSpeedPrioritizeUploadSpeed(value: Boolean) {
+        prefs.edit().putBoolean(KEY_NETWORK_SPEED_PRIORITIZE_UPLOAD, value).apply()
+    }
+
+    fun getNetworkSpeedChipBackgroundDisabled(): Boolean {
+        return prefs.getBoolean(KEY_NETWORK_SPEED_DISABLE_CHIP_BACKGROUND, false)
+    }
+
+    fun setNetworkSpeedChipBackgroundDisabled(value: Boolean) {
+        prefs.edit().putBoolean(KEY_NETWORK_SPEED_DISABLE_CHIP_BACKGROUND, value).apply()
+    }
+
+    fun getNetworkSpeedUnit(): String {
+        val raw = prefs.getString(KEY_NETWORK_SPEED_UNIT, NetworkSpeedUnit.AUTO.id)
+        return NetworkSpeedUnit.normalizeSelection(raw)
+    }
+
+    fun setNetworkSpeedUnit(value: String?) {
+        val normalized = NetworkSpeedUnit.normalizeSelection(value)
+        prefs.edit().putString(KEY_NETWORK_SPEED_UNIT, normalized).apply()
+    }
+
+    fun getNetworkSpeedSettings(): NetworkSpeedSettings {
+        return NetworkSpeedSettings(
+            enabled = getNetworkSpeedEnabled(),
+            displayMode = getNetworkSpeedDisplayMode(),
+            uploadPrefix = getNetworkSpeedUploadPrefix(),
+            downloadPrefix = getNetworkSpeedDownloadPrefix(),
+            prioritizeUploadSpeed = getNetworkSpeedPrioritizeUploadSpeed(),
+            chipBackgroundDisabled = getNetworkSpeedChipBackgroundDisabled(),
+            unitSelection = getNetworkSpeedUnit(),
+        )
+    }
+
     fun getOtpDetectionEnabled(): Boolean {
         return prefs.getBoolean(KEY_OTP_DETECTION_ENABLED, true)
     }
@@ -394,6 +487,15 @@ class ConverterPrefs(context: Context) {
         private const val KEY_SMART_WEATHER_ENABLED = "smart_weather_enabled"
         private const val KEY_SMART_EXTERNAL_DEVICES_ENABLED = "smart_external_devices_enabled"
         private const val KEY_SMART_VPN_ENABLED = "smart_vpn_enabled"
+        private const val KEY_NETWORK_SPEED_ENABLED = "network_speed_enabled"
+        private const val KEY_NETWORK_SPEED_DISPLAY_MODE = "network_speed_display_mode"
+        private const val KEY_NETWORK_SPEED_UPLOAD_PREFIX = "network_speed_upload_prefix"
+        private const val KEY_NETWORK_SPEED_DOWNLOAD_PREFIX = "network_speed_download_prefix"
+        private const val KEY_NETWORK_SPEED_PRIORITIZE_UPLOAD =
+            "network_speed_prioritize_upload"
+        private const val KEY_NETWORK_SPEED_DISABLE_CHIP_BACKGROUND =
+            "network_speed_disable_chip_background"
+        private const val KEY_NETWORK_SPEED_UNIT = "network_speed_unit"
         private const val KEY_OTP_DETECTION_ENABLED = "otp_detection_enabled"
         private const val KEY_OTP_AUTO_COPY_ENABLED = "otp_auto_copy_enabled"
         private const val KEY_OTP_PACKAGE_RULES = "otp_package_rules"

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/KeepAliveForegroundService.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/KeepAliveForegroundService.kt
@@ -14,6 +14,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.appsfolder.livebridge.MainActivity
 import com.appsfolder.livebridge.R
+import java.util.Locale
 
 class KeepAliveForegroundService : Service() {
     override fun onCreate() {
@@ -43,6 +44,7 @@ class KeepAliveForegroundService : Service() {
     }
 
     private fun buildNotification(): Notification {
+        val text = localizedText(this)
         val contentIntent = PendingIntent.getActivity(
             this,
             0,
@@ -54,8 +56,8 @@ class KeepAliveForegroundService : Service() {
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_stat_liveupdate)
-            .setContentTitle("background mode")
-            .setContentText("Keep this notification here for LiveBridge stability")
+            .setContentTitle(text.title)
+            .setContentText(text.body)
             .setContentIntent(contentIntent)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
@@ -85,17 +87,54 @@ class KeepAliveForegroundService : Service() {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 return
             }
+            val text = localizedText(context)
             val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             val existing = manager.getNotificationChannel(CHANNEL_ID)
             if (existing != null) {
                 return
             }
             manager.createNotificationChannel(
-                NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW).apply {
-                    description = "Keep this notification here to use LiveBridge"
+                NotificationChannel(
+                    CHANNEL_ID,
+                    text.channelName,
+                    NotificationManager.IMPORTANCE_LOW
+                ).apply {
+                    description = text.channelDescription
                     lockscreenVisibility = Notification.VISIBILITY_SECRET
                 }
             )
         }
+
+        private fun localizedText(context: Context): LocalizedText {
+            val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                context.resources.configuration.locales.get(0)
+            } else {
+                @Suppress("DEPRECATION")
+                context.resources.configuration.locale
+            }
+            val isRu = locale?.language?.lowercase(Locale.ROOT)?.startsWith("ru") == true
+            return if (isRu) {
+                LocalizedText(
+                    title = "Фоновый режим",
+                    body = "Оставьте это уведомление для стабильной работы LiveBridge",
+                    channelName = "Фоновый режим LiveBridge",
+                    channelDescription = "Оставьте это уведомление, чтобы LiveBridge работал стабильно"
+                )
+            } else {
+                LocalizedText(
+                    title = "Background mode",
+                    body = "Keep this notification for LiveBridge stability",
+                    channelName = CHANNEL_NAME,
+                    channelDescription = "Keep this notification to use LiveBridge"
+                )
+            }
+        }
     }
+
+    private data class LocalizedText(
+        val title: String,
+        val body: String,
+        val channelName: String,
+        val channelDescription: String,
+    )
 }

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/LiveBridgeTileService.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/LiveBridgeTileService.kt
@@ -8,6 +8,7 @@ import android.service.notification.NotificationListenerService
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import androidx.core.app.NotificationManagerCompat
+import com.appsfolder.livebridge.liveupdate.networkspeed.NetworkSpeedController
 
 class LiveBridgeTileService : TileService() {
     private val prefs by lazy { ConverterPrefs(applicationContext) }
@@ -29,6 +30,7 @@ class LiveBridgeTileService : TileService() {
     private fun toggleConverter() {
         val newValue = !prefs.getConverterEnabled()
         prefs.setConverterEnabled(newValue)
+        NetworkSpeedController.sync(applicationContext, prefs)
         if (!newValue) {
             LiveUpdateNotifier.clearRuntimeState()
             NotificationManagerCompat.from(applicationContext).cancelAll()

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedBootReceiver.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedBootReceiver.kt
@@ -1,0 +1,18 @@
+package com.appsfolder.livebridge.liveupdate.networkspeed
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class NetworkSpeedBootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (
+            intent.action != Intent.ACTION_BOOT_COMPLETED &&
+            intent.action != "android.intent.action.QUICKBOOT_POWERON"
+        ) {
+            return
+        }
+
+        NetworkSpeedController.sync(context)
+    }
+}

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedController.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedController.kt
@@ -1,0 +1,74 @@
+package com.appsfolder.livebridge.liveupdate.networkspeed
+
+import android.Manifest
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.appsfolder.livebridge.liveupdate.ConverterPrefs
+import com.appsfolder.livebridge.liveupdate.DeviceBlocker
+import com.appsfolder.livebridge.liveupdate.LiveUpdateNotificationListenerService
+
+object NetworkSpeedController {
+    fun sync(
+        context: Context,
+        prefs: ConverterPrefs = ConverterPrefs(context),
+    ) {
+        if (shouldRun(context, prefs)) {
+            start(context)
+        } else {
+            stop(context)
+        }
+    }
+
+    fun start(context: Context) {
+        ContextCompat.startForegroundService(
+            context,
+            Intent(context, NetworkSpeedForegroundService::class.java),
+        )
+    }
+
+    fun stop(context: Context) {
+        context.stopService(Intent(context, NetworkSpeedForegroundService::class.java))
+    }
+
+    fun shouldRun(
+        context: Context,
+        prefs: ConverterPrefs = ConverterPrefs(context),
+    ): Boolean {
+        if (!prefs.getConverterEnabled() || !prefs.getNetworkSpeedEnabled()) {
+            return false
+        }
+        if (!isNotificationListenerEnabled(context)) {
+            return false
+        }
+        if (DeviceBlocker.isBlockedDevice() && !prefs.getPixelJokeBypassEnabled()) {
+            return false
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val permissionGranted = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!permissionGranted) {
+                return false
+            }
+        }
+        return NotificationManagerCompat.from(context).areNotificationsEnabled()
+    }
+
+    private fun isNotificationListenerEnabled(context: Context): Boolean {
+        val enabled = Settings.Secure.getString(
+            context.contentResolver,
+            "enabled_notification_listeners",
+        ) ?: return false
+        val service = ComponentName(context, LiveUpdateNotificationListenerService::class.java)
+        return enabled.split(":")
+            .mapNotNull(ComponentName::unflattenFromString)
+            .any { it == service }
+    }
+}

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedDataSource.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedDataSource.kt
@@ -1,0 +1,144 @@
+package com.appsfolder.livebridge.liveupdate.networkspeed
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.TrafficStats
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.Closeable
+import java.util.concurrent.ConcurrentHashMap
+
+data class NetworkTrafficData(
+    val rxBytes: Long,
+    val txBytes: Long,
+)
+
+data class NetworkSpeedSample(
+    val downloadBytesPerSecond: Long = 0L,
+    val uploadBytesPerSecond: Long = 0L,
+) {
+    val totalBytesPerSecond: Long
+        get() = downloadBytesPerSecond + uploadBytesPerSecond
+}
+
+class NetworkSpeedDataSource(context: Context) : Closeable {
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val validInterfaces = ConcurrentHashMap<Network, String>()
+    private var callbackRegistered = false
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onCapabilitiesChanged(
+            network: Network,
+            networkCapabilities: NetworkCapabilities,
+        ) {
+            super.onCapabilitiesChanged(network, networkCapabilities)
+            updateNetwork(
+                network = network,
+                capabilities = networkCapabilities,
+                linkProperties = connectivityManager.getLinkProperties(network),
+            )
+        }
+
+        override fun onLinkPropertiesChanged(network: Network, linkProperties: LinkProperties) {
+            super.onLinkPropertiesChanged(network, linkProperties)
+            updateNetwork(
+                network = network,
+                capabilities = connectivityManager.getNetworkCapabilities(network),
+                linkProperties = linkProperties,
+            )
+        }
+
+        override fun onLost(network: Network) {
+            super.onLost(network)
+            validInterfaces.remove(network)
+        }
+    }
+
+    init {
+        registerCallback()
+        seedExistingNetworks()
+    }
+
+    suspend fun getTrafficData(): NetworkTrafficData = withContext(Dispatchers.Default) {
+        var totalRx = 0L
+        var totalTx = 0L
+        val interfaceNames = validInterfaces.values.toSet()
+
+        interfaceNames.forEach { ifaceName ->
+            val rxBytes = TrafficStats.getRxBytes(ifaceName)
+            val txBytes = TrafficStats.getTxBytes(ifaceName)
+            if (rxBytes != TrafficStats.UNSUPPORTED.toLong()) {
+                totalRx += rxBytes.coerceAtLeast(0L)
+            }
+            if (txBytes != TrafficStats.UNSUPPORTED.toLong()) {
+                totalTx += txBytes.coerceAtLeast(0L)
+            }
+        }
+
+        NetworkTrafficData(rxBytes = totalRx, txBytes = totalTx)
+    }
+
+    override fun close() {
+        if (!callbackRegistered) {
+            return
+        }
+        runCatching {
+            connectivityManager.unregisterNetworkCallback(networkCallback)
+        }
+        callbackRegistered = false
+        validInterfaces.clear()
+    }
+
+    private fun registerCallback() {
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+            .addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
+            .build()
+
+        runCatching {
+            connectivityManager.registerNetworkCallback(request, networkCallback)
+            callbackRegistered = true
+        }
+    }
+
+    private fun seedExistingNetworks() {
+        connectivityManager.allNetworks.forEach { network ->
+            updateNetwork(
+                network = network,
+                capabilities = connectivityManager.getNetworkCapabilities(network),
+                linkProperties = connectivityManager.getLinkProperties(network),
+            )
+        }
+    }
+
+    private fun updateNetwork(
+        network: Network,
+        capabilities: NetworkCapabilities?,
+        linkProperties: LinkProperties?,
+    ) {
+        if (capabilities == null || linkProperties == null) {
+            validInterfaces.remove(network)
+            return
+        }
+
+        val isVpn = capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+        val isPhysical =
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+        val interfaceName = linkProperties.interfaceName
+
+        if (isVpn || !isPhysical || interfaceName.isNullOrBlank()) {
+            validInterfaces.remove(network)
+            return
+        }
+
+        validInterfaces[network] = interfaceName
+    }
+}

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedForegroundService.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedForegroundService.kt
@@ -1,0 +1,157 @@
+package com.appsfolder.livebridge.liveupdate.networkspeed
+
+import android.app.Notification
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.os.SystemClock
+import androidx.core.app.NotificationManagerCompat
+import com.appsfolder.livebridge.liveupdate.ConverterPrefs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class NetworkSpeedForegroundService : Service() {
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private lateinit var prefs: ConverterPrefs
+    private lateinit var notificationBuilder: NetworkSpeedNotificationBuilder
+    private lateinit var notificationManager: NotificationManagerCompat
+    private var dataSource: NetworkSpeedDataSource? = null
+    private var monitoringJob: Job? = null
+    private var lastTotalRxBytes: Long = 0L
+    private var lastTotalTxBytes: Long = 0L
+    private var lastSampleAtMs: Long = 0L
+    private var latestSample = NetworkSpeedSample()
+
+    override fun onCreate() {
+        super.onCreate()
+        prefs = ConverterPrefs(applicationContext)
+        notificationBuilder = NetworkSpeedNotificationBuilder(applicationContext)
+        notificationManager = NotificationManagerCompat.from(applicationContext)
+        dataSource = NetworkSpeedDataSource(applicationContext)
+        notificationBuilder.ensureChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!NetworkSpeedController.shouldRun(applicationContext, prefs)) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        startForegroundCompat(
+            notificationBuilder.build(
+                sample = latestSample,
+                settings = prefs.getNetworkSpeedSettings(),
+            ),
+        )
+        startMonitoringIfNeeded()
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        monitoringJob?.cancel()
+        monitoringJob = null
+        dataSource?.close()
+        dataSource = null
+        serviceScope.cancel()
+        notificationManager.cancel(NOTIFICATION_ID)
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    private fun startForegroundCompat(notification: Notification) {
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE or
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            }
+
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            }
+
+            else -> {
+                @Suppress("DEPRECATION")
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        }
+    }
+
+    private fun startMonitoringIfNeeded() {
+        if (monitoringJob?.isActive == true) {
+            return
+        }
+
+        monitoringJob = serviceScope.launch {
+            while (isActive) {
+                if (!NetworkSpeedController.shouldRun(applicationContext, prefs)) {
+                    withContext(Dispatchers.Main) {
+                        stopSelf()
+                    }
+                    return@launch
+                }
+
+                val startedAtMs = SystemClock.elapsedRealtime()
+                val trafficData = dataSource?.getTrafficData() ?: NetworkTrafficData(0L, 0L)
+                val nowMs = SystemClock.elapsedRealtime()
+
+                if (lastSampleAtMs != 0L) {
+                    val deltaMs = nowMs - lastSampleAtMs
+                    val downloadDelta = trafficData.rxBytes - lastTotalRxBytes
+                    val uploadDelta = trafficData.txBytes - lastTotalTxBytes
+
+                    if (deltaMs > 0L) {
+                        latestSample = NetworkSpeedSample(
+                            downloadBytesPerSecond = ((downloadDelta * 1000L) / deltaMs)
+                                .coerceAtLeast(0L),
+                            uploadBytesPerSecond = ((uploadDelta * 1000L) / deltaMs)
+                                .coerceAtLeast(0L),
+                        )
+                        publishCurrentNotification()
+                    }
+                }
+
+                lastTotalRxBytes = trafficData.rxBytes
+                lastTotalTxBytes = trafficData.txBytes
+                lastSampleAtMs = nowMs
+
+                val elapsedMs = SystemClock.elapsedRealtime() - startedAtMs
+                delay((POLL_INTERVAL_MS - elapsedMs).coerceAtLeast(0L))
+            }
+        }
+    }
+
+    private fun publishCurrentNotification() {
+        notificationManager.notify(
+            NOTIFICATION_ID,
+            notificationBuilder.build(
+                sample = latestSample,
+                settings = prefs.getNetworkSpeedSettings(),
+            ),
+        )
+    }
+
+    companion object {
+        private const val POLL_INTERVAL_MS = 1500L
+        const val NOTIFICATION_ID = 45100
+    }
+}

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedFormatter.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedFormatter.kt
@@ -1,0 +1,113 @@
+package com.appsfolder.livebridge.liveupdate.networkspeed
+
+import java.util.Locale
+
+object NetworkSpeedFormatter {
+    fun formatChipText(
+        bytesPerSecond: Long,
+        rawUnit: String?,
+    ): String {
+        return when (resolveDisplayUnit(rawUnit, bytesPerSecond)) {
+            NetworkSpeedUnit.BYTES -> "${formatFixedValue(bytesPerSecond.toDouble())}B/s"
+            NetworkSpeedUnit.KILOBYTES -> "${formatFixedValue(bytesPerSecond / 1024.0)}K/s"
+            NetworkSpeedUnit.MEGABYTES -> "${formatFixedValue(bytesPerSecond / 1048576.0)}M/s"
+            NetworkSpeedUnit.GIGABYTES -> "${formatFixedValue(bytesPerSecond / 1073741824.0)}G/s"
+            NetworkSpeedUnit.AUTO -> {
+                if (bytesPerSecond < 1024) {
+                    return "${bytesPerSecond}B/s"
+                }
+                val kb = bytesPerSecond / 1024.0
+                if (kb < 1000) {
+                    return "${"%.0f".format(Locale.getDefault(), kb)}K/s"
+                }
+                val mb = kb / 1024.0
+                if (mb < 1000) {
+                    return if (mb < 100) {
+                        "${"%.1f".format(Locale.getDefault(), mb)}M/s"
+                    } else {
+                        "${"%.0f".format(Locale.getDefault(), mb)}M/s"
+                    }
+                }
+                val gb = mb / 1024.0
+                "${"%.1f".format(Locale.getDefault(), gb)}G/s"
+            }
+        }
+    }
+
+    fun formatSpeedText(
+        bytesPerSecond: Long,
+        rawUnit: String?,
+    ): Pair<String, String> {
+        return when (resolveDisplayUnit(rawUnit, bytesPerSecond)) {
+            NetworkSpeedUnit.BYTES -> formatFixedValue(bytesPerSecond.toDouble()) to "B/s"
+            NetworkSpeedUnit.KILOBYTES -> formatFixedValue(bytesPerSecond / 1024.0) to "KB/s"
+            NetworkSpeedUnit.MEGABYTES -> formatFixedValue(bytesPerSecond / 1048576.0) to "MB/s"
+            NetworkSpeedUnit.GIGABYTES -> formatFixedValue(bytesPerSecond / 1073741824.0) to "GB/s"
+            NetworkSpeedUnit.AUTO -> {
+                if (bytesPerSecond < 1024) {
+                    return bytesPerSecond.toString() to "B/s"
+                }
+                val kb = bytesPerSecond / 1024.0
+                if (kb < 1000) {
+                    return "%.0f".format(Locale.getDefault(), kb) to "KB/s"
+                }
+                val mb = kb / 1024.0
+                if (mb < 1000) {
+                    return if (mb < 10) {
+                        "%.1f".format(Locale.getDefault(), mb) to "MB/s"
+                    } else {
+                        "%.0f".format(Locale.getDefault(), mb) to "MB/s"
+                    }
+                }
+                val gb = mb / 1024.0
+                "%.1f".format(Locale.getDefault(), gb) to "GB/s"
+            }
+        }
+    }
+
+    fun formatLine(
+        bytesPerSecond: Long,
+        rawUnit: String?,
+    ): String {
+        val (value, unit) = formatSpeedText(bytesPerSecond, rawUnit)
+        return "$value$unit"
+    }
+
+    private fun resolveDisplayUnit(
+        rawUnit: String?,
+        bytesPerSecond: Long,
+    ): NetworkSpeedUnit {
+        val selectedUnits = NetworkSpeedUnit.parseSelection(rawUnit)
+        if (selectedUnits.isEmpty() || selectedUnits.contains(NetworkSpeedUnit.AUTO)) {
+            return NetworkSpeedUnit.AUTO
+        }
+
+        val fixedUnits = selectedUnits
+            .filter { it != NetworkSpeedUnit.AUTO }
+            .sortedByDescending { it.ordinal }
+        var bestUnit = fixedUnits.last()
+        for (unit in fixedUnits) {
+            val threshold =
+                when (unit) {
+                    NetworkSpeedUnit.GIGABYTES -> 1000L * 1024L * 1024L
+                    NetworkSpeedUnit.MEGABYTES -> 1000L * 1024L
+                    NetworkSpeedUnit.KILOBYTES -> 1024L
+                    NetworkSpeedUnit.BYTES,
+                    NetworkSpeedUnit.AUTO -> 0L
+                }
+            if (bytesPerSecond >= threshold) {
+                bestUnit = unit
+                break
+            }
+        }
+        return bestUnit
+    }
+
+    private fun formatFixedValue(value: Double): String {
+        return when {
+            value < 10 -> "%.2f".format(Locale.getDefault(), value)
+            value < 100 -> "%.1f".format(Locale.getDefault(), value)
+            else -> "%.0f".format(Locale.getDefault(), value)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedNotificationBuilder.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedNotificationBuilder.kt
@@ -1,0 +1,142 @@
+package com.appsfolder.livebridge.liveupdate.networkspeed
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationChannelGroup
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.appsfolder.livebridge.MainActivity
+import com.appsfolder.livebridge.R
+
+class NetworkSpeedNotificationBuilder(
+    private val context: Context,
+) {
+    fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val group = NotificationChannelGroup(CHANNEL_ID, localizedText().channelName)
+        notificationManager.createNotificationChannelGroup(group)
+
+        if (notificationManager.getNotificationChannel(CHANNEL_ID) != null) {
+            return
+        }
+
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            localizedText().channelName,
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).apply {
+            description = localizedText().channelDescription
+            setShowBadge(false)
+            setGroup(CHANNEL_ID)
+            setSound(null, null)
+        }
+
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    fun build(
+        sample: NetworkSpeedSample,
+        settings: NetworkSpeedSettings,
+    ): Notification {
+        ensureChannel()
+
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val contentText = buildContentText(sample, settings)
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setContentIntent(contentIntent)
+            .setVisibility(NotificationCompat.VISIBILITY_SECRET)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+
+        val statusText = NetworkSpeedFormatter.formatChipText(
+            sample.totalBytesPerSecond,
+            settings.unitSelection,
+        )
+
+        return builder
+            .setContentTitle(localizedText().notificationTitle)
+            .setContentText(contentText)
+            .setSmallIcon(R.drawable.ic_speed)
+            .setColor(PROGRESS_COLOR)
+            .setShortCriticalText(statusText)
+            .setRequestPromotedOngoing(true)
+            .build()
+    }
+
+    private fun buildContentText(
+        sample: NetworkSpeedSample,
+        settings: NetworkSpeedSettings,
+    ): String {
+        val uploadText =
+            "${settings.uploadPrefix}${NetworkSpeedFormatter.formatLine(sample.uploadBytesPerSecond, settings.unitSelection)}"
+        val downloadText =
+            "${settings.downloadPrefix}${NetworkSpeedFormatter.formatLine(sample.downloadBytesPerSecond, settings.unitSelection)}"
+
+        return when (settings.displayMode) {
+            NetworkSpeedDisplayMode.UPLOAD_ONLY -> uploadText
+            NetworkSpeedDisplayMode.DOWNLOAD_ONLY -> downloadText
+            NetworkSpeedDisplayMode.TOTAL ->
+                if (settings.prioritizeUploadSpeed) {
+                    "$uploadText  $downloadText"
+                } else {
+                    "$downloadText  $uploadText"
+                }
+        }
+    }
+
+    private fun localizedText(): LocalizedText {
+        return if (isRussianLocale()) {
+            LocalizedText(
+                notificationTitle = "\u0421\u043a\u043e\u0440\u043e\u0441\u0442\u044c \u0438\u043d\u0442\u0435\u0440\u043d\u0435\u0442\u0430",
+                channelName = "\u041c\u043e\u043d\u0438\u0442\u043e\u0440 \u0441\u043a\u043e\u0440\u043e\u0441\u0442\u0438 \u0441\u0435\u0442\u0438",
+                channelDescription = "\u041f\u043e\u043a\u0430\u0437\u044b\u0432\u0430\u0435\u0442 \u0441\u043a\u043e\u0440\u043e\u0441\u0442\u044c \u0441\u0435\u0442\u0438 \u0432 \u0441\u0442\u0430\u0442\u0443\u0441 \u0431\u0430\u0440\u0435",
+            )
+        } else {
+            LocalizedText(
+                notificationTitle = "Network speed",
+                channelName = "Network Monitor Service",
+                channelDescription = "Shows real-time network speed in status bar",
+            )
+        }
+    }
+
+    private fun isRussianLocale(): Boolean {
+        val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context.resources.configuration.locales.get(0)
+        } else {
+            @Suppress("DEPRECATION")
+            context.resources.configuration.locale
+        }
+        return locale?.language?.startsWith("ru", ignoreCase = true) == true
+    }
+
+    private data class LocalizedText(
+        val notificationTitle: String,
+        val channelName: String,
+        val channelDescription: String,
+    )
+
+    companion object {
+        const val CHANNEL_ID = "net_monitor_silent"
+        private const val PROGRESS_COLOR = 0xFF0F766E.toInt()
+    }
+}

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedSettings.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/networkspeed/NetworkSpeedSettings.kt
@@ -1,0 +1,77 @@
+package com.appsfolder.livebridge.liveupdate.networkspeed
+
+data class NetworkSpeedSettings(
+    val enabled: Boolean = false,
+    val displayMode: NetworkSpeedDisplayMode = NetworkSpeedDisplayMode.TOTAL,
+    val uploadPrefix: String = DEFAULT_UPLOAD_PREFIX,
+    val downloadPrefix: String = DEFAULT_DOWNLOAD_PREFIX,
+    val prioritizeUploadSpeed: Boolean = true,
+    val chipBackgroundDisabled: Boolean = false,
+    val unitSelection: String = NetworkSpeedUnit.AUTO.id,
+) {
+    fun toMap(): Map<String, Any> {
+        return mapOf(
+            "enabled" to enabled,
+            "display_mode" to displayMode.id,
+            "upload_prefix" to uploadPrefix,
+            "download_prefix" to downloadPrefix,
+            "prioritize_upload_speed" to prioritizeUploadSpeed,
+            "chip_background_disabled" to chipBackgroundDisabled,
+            "unit" to unitSelection,
+        )
+    }
+
+    companion object {
+        const val DEFAULT_UPLOAD_PREFIX = "\u25B2 "
+        const val DEFAULT_DOWNLOAD_PREFIX = "\u25BC "
+    }
+}
+
+enum class NetworkSpeedDisplayMode(val id: String) {
+    TOTAL("total"),
+    UPLOAD_ONLY("upload_only"),
+    DOWNLOAD_ONLY("download_only");
+
+    companion object {
+        fun from(raw: String?): NetworkSpeedDisplayMode {
+            return entries.firstOrNull { it.id == raw } ?: TOTAL
+        }
+    }
+}
+
+enum class NetworkSpeedUnit(val id: String) {
+    AUTO("auto"),
+    BYTES("bytes"),
+    KILOBYTES("kilobytes"),
+    MEGABYTES("megabytes"),
+    GIGABYTES("gigabytes");
+
+    companion object {
+        fun parseSelection(raw: String?): Set<NetworkSpeedUnit> {
+            return raw.orEmpty()
+                .split(",")
+                .mapNotNull { token ->
+                    entries.firstOrNull { it.id == token.trim() }
+                }
+                .toSet()
+        }
+
+        fun normalizeSelection(raw: String?): String {
+            if (raw == null) {
+                return AUTO.id
+            }
+
+            val selected = parseSelection(raw)
+            if (selected.isEmpty()) {
+                return AUTO.id
+            }
+            if (selected.contains(AUTO)) {
+                return AUTO.id
+            }
+
+            return entries
+                .filter { it != AUTO && selected.contains(it) }
+                .joinToString(",") { it.id }
+        }
+    }
+}

--- a/android/app/src/main/res/drawable/ic_speed.xml
+++ b/android/app/src/main/res/drawable/ic_speed.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M320,520L320,233L217,336L160,280L360,80L560,280L503,336L400,233L400,520L320,520ZM600,880L400,680L457,624L560,727L560,440L640,440L640,727L743,624L800,680L600,880Z" />
+</vector>

--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -279,6 +279,58 @@ class AppStrings {
   String get smartVpnSubtitle => isRu
       ? 'Показывает входящий/исходящий трафик в формате *b/s.'
       : 'Shows incoming/outgoing traffic speed in *b/s format.';
+
+  String get networkSpeedTitle => isRu ? 'Скорость интернета' : 'Network speed';
+  String get networkSpeedSubtitle => isRu
+      ? 'Показывает скорость сети отдельным Live Update в статус баре.'
+      : 'Shows network speed as a separate Live Update in the status bar.';
+  String get networkSpeedEnabledTitle => isRu
+      ? 'Показывать скорость сети в статус баре'
+      : 'Show network speed in status bar';
+  String get networkSpeedEnabledSubtitle => isRu
+      ? 'Запускает отдельное уведомление с текущей скоростью сети и выводит его в статус бар.'
+      : 'Runs a dedicated ongoing notification with current network speed and surfaces it in the status bar.';
+  String get networkSpeedEnabledMasterOffSubtitle => isRu
+      ? 'Включится после активации общего тумблера LiveBridge.'
+      : 'Will activate after the main LiveBridge toggle is enabled.';
+  String get networkSpeedDisplayContentLabel =>
+      isRu ? 'Отображаемый контент' : 'Display content';
+  String get networkSpeedDisplayContentTitle =>
+      isRu ? 'Отображаемый контент' : 'Display content';
+  String get networkSpeedDisplayModeTotal =>
+      isRu ? 'Общая скорость' : 'Total speed';
+  String get networkSpeedDisplayModeUploadOnly =>
+      isRu ? 'Только upload' : 'Upload only';
+  String get networkSpeedDisplayModeDownloadOnly =>
+      isRu ? 'Только download' : 'Download only';
+  String get networkSpeedUploadPrefixLabel =>
+      isRu ? 'Префикс upload' : 'Upload prefix';
+  String get networkSpeedDownloadPrefixLabel =>
+      isRu ? 'Префикс download' : 'Download prefix';
+  String get networkSpeedPrefixEditorHint => isRu
+      ? 'Введите префикс или оставьте пустым.'
+      : 'Enter a prefix or leave it empty.';
+  String get networkSpeedPrefixPreviewLabel =>
+      isRu ? 'Текущее значение' : 'Current value';
+  String networkSpeedCurrentValue(String value) =>
+      isRu ? 'Сейчас: "$value"' : 'Current: "$value"';
+  String get networkSpeedPrioritizeUploadTitle =>
+      isRu ? 'Сначала показывать upload' : 'Prioritize upload speed';
+  String get networkSpeedPrioritizeUploadSubtitle => isRu
+      ? 'В режиме общей скорости строка upload будет показана первой.'
+      : 'In total mode, upload speed is shown first.';
+  String get networkSpeedUnitLabel => isRu ? 'Единица скорости' : 'Speed unit';
+  String get networkSpeedUnitTitle => isRu ? 'Единица скорости' : 'Speed unit';
+  String get networkSpeedUnitSubtitle => isRu
+      ? 'Выберите автоматический режим или зафиксируйте несколько единиц.'
+      : 'Choose automatic mode or pin multiple units.';
+  String get networkSpeedUnitAuto => isRu ? 'Авто' : 'Auto';
+  String get networkSpeedDisableChipBackgroundTitle =>
+      isRu ? 'Отключить фон chips' : 'Disable chip background';
+  String get networkSpeedDisableChipBackgroundSubtitle => isRu
+      ? 'Убирает фон у chips скорости в статус баре, но оставляет акцент у иконки в развернутом уведомлении.'
+      : 'Removes the background from network speed chips in the status bar while keeping the icon accent in the expanded notification.';
+
   String get smartNavigationDisabledSubtitle => isRu
       ? 'Сначала включите умное распознавание.'
       : 'Enable smart status detection first.';
@@ -306,7 +358,7 @@ class AppStrings {
       ? 'LiveBridge плохо работает на устройствах с AOSP. Можете продолжить, но за последствия я не отвечаю.'
       : 'LiveBridge is not designed for AOSP. You can continue, but i am not responsible for any bugs.';
   String get blockedBypassAction =>
-      isRu ? 'Все равно родолжить' : 'Continue anyway';
+      isRu ? 'Все равно продолжить' : 'Continue anyway';
   String get blockedBypassSaveFailed =>
       isRu ? 'Не удалось сохранить выбор.' : 'Unable to save your choice.';
 

--- a/lib/models/network_speed_models.dart
+++ b/lib/models/network_speed_models.dart
@@ -1,0 +1,186 @@
+class NetworkSpeedSettings {
+  const NetworkSpeedSettings({
+    this.enabled = false,
+    this.displayMode = NetworkSpeedDisplayMode.total,
+    this.uploadPrefix = defaultUploadPrefix,
+    this.downloadPrefix = defaultDownloadPrefix,
+    this.prioritizeUploadSpeed = true,
+    this.chipBackgroundDisabled = false,
+    this.units = const <NetworkSpeedUnit>{NetworkSpeedUnit.auto},
+  });
+
+  static const String defaultUploadPrefix = '\u25B2 ';
+  static const String defaultDownloadPrefix = '\u25BC ';
+
+  final bool enabled;
+  final NetworkSpeedDisplayMode displayMode;
+  final String uploadPrefix;
+  final String downloadPrefix;
+  final bool prioritizeUploadSpeed;
+  final bool chipBackgroundDisabled;
+  final Set<NetworkSpeedUnit> units;
+
+  NetworkSpeedSettings copyWith({
+    bool? enabled,
+    NetworkSpeedDisplayMode? displayMode,
+    String? uploadPrefix,
+    String? downloadPrefix,
+    bool? prioritizeUploadSpeed,
+    bool? chipBackgroundDisabled,
+    Set<NetworkSpeedUnit>? units,
+  }) {
+    return NetworkSpeedSettings(
+      enabled: enabled ?? this.enabled,
+      displayMode: displayMode ?? this.displayMode,
+      uploadPrefix: uploadPrefix ?? this.uploadPrefix,
+      downloadPrefix: downloadPrefix ?? this.downloadPrefix,
+      prioritizeUploadSpeed:
+          prioritizeUploadSpeed ?? this.prioritizeUploadSpeed,
+      chipBackgroundDisabled:
+          chipBackgroundDisabled ?? this.chipBackgroundDisabled,
+      units: Set<NetworkSpeedUnit>.from(units ?? this.units),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'enabled': enabled,
+      'display_mode': displayMode.id,
+      'upload_prefix': uploadPrefix,
+      'download_prefix': downloadPrefix,
+      'prioritize_upload_speed': prioritizeUploadSpeed,
+      'chip_background_disabled': chipBackgroundDisabled,
+      'unit': NetworkSpeedUnitSelection.encode(units),
+    };
+  }
+
+  static NetworkSpeedSettings fromMap(Map<String, dynamic> map) {
+    final Object? rawUploadPrefix = map['upload_prefix'];
+    final Object? rawDownloadPrefix = map['download_prefix'];
+    return NetworkSpeedSettings(
+      enabled: map['enabled'] == true,
+      displayMode: NetworkSpeedDisplayModeId.from(
+        map['display_mode'] as String?,
+      ),
+      uploadPrefix: rawUploadPrefix is String
+          ? rawUploadPrefix
+          : defaultUploadPrefix,
+      downloadPrefix: rawDownloadPrefix is String
+          ? rawDownloadPrefix
+          : defaultDownloadPrefix,
+      prioritizeUploadSpeed: map['prioritize_upload_speed'] != false,
+      chipBackgroundDisabled: map['chip_background_disabled'] == true,
+      units: Set<NetworkSpeedUnit>.from(
+        NetworkSpeedUnitSelection.parse(map['unit'] as String?),
+      ),
+    );
+  }
+}
+
+enum NetworkSpeedDisplayMode { total, uploadOnly, downloadOnly }
+
+extension NetworkSpeedDisplayModeId on NetworkSpeedDisplayMode {
+  String get id {
+    switch (this) {
+      case NetworkSpeedDisplayMode.total:
+        return 'total';
+      case NetworkSpeedDisplayMode.uploadOnly:
+        return 'upload_only';
+      case NetworkSpeedDisplayMode.downloadOnly:
+        return 'download_only';
+    }
+  }
+
+  static NetworkSpeedDisplayMode from(String? value) {
+    switch (value) {
+      case 'upload_only':
+        return NetworkSpeedDisplayMode.uploadOnly;
+      case 'download_only':
+        return NetworkSpeedDisplayMode.downloadOnly;
+      default:
+        return NetworkSpeedDisplayMode.total;
+    }
+  }
+}
+
+enum NetworkSpeedUnit { auto, bytes, kilobytes, megabytes, gigabytes }
+
+const List<NetworkSpeedUnit> kNetworkSpeedUnitValues = <NetworkSpeedUnit>[
+  NetworkSpeedUnit.auto,
+  NetworkSpeedUnit.bytes,
+  NetworkSpeedUnit.kilobytes,
+  NetworkSpeedUnit.megabytes,
+  NetworkSpeedUnit.gigabytes,
+];
+
+extension NetworkSpeedUnitId on NetworkSpeedUnit {
+  String get id {
+    switch (this) {
+      case NetworkSpeedUnit.auto:
+        return 'auto';
+      case NetworkSpeedUnit.bytes:
+        return 'bytes';
+      case NetworkSpeedUnit.kilobytes:
+        return 'kilobytes';
+      case NetworkSpeedUnit.megabytes:
+        return 'megabytes';
+      case NetworkSpeedUnit.gigabytes:
+        return 'gigabytes';
+    }
+  }
+
+  static NetworkSpeedUnit? tryFrom(String? value) {
+    switch (value) {
+      case 'auto':
+        return NetworkSpeedUnit.auto;
+      case 'bytes':
+        return NetworkSpeedUnit.bytes;
+      case 'kilobytes':
+        return NetworkSpeedUnit.kilobytes;
+      case 'megabytes':
+        return NetworkSpeedUnit.megabytes;
+      case 'gigabytes':
+        return NetworkSpeedUnit.gigabytes;
+      default:
+        return null;
+    }
+  }
+}
+
+class NetworkSpeedUnitSelection {
+  static Set<NetworkSpeedUnit> parse(String? raw) {
+    final Set<NetworkSpeedUnit> parsed = (raw ?? '')
+        .split(',')
+        .map((String token) => NetworkSpeedUnitId.tryFrom(token.trim()))
+        .whereType<NetworkSpeedUnit>()
+        .toSet();
+    if (parsed.isEmpty || parsed.contains(NetworkSpeedUnit.auto)) {
+      return const <NetworkSpeedUnit>{NetworkSpeedUnit.auto};
+    }
+    return parsed;
+  }
+
+  static String encode(Set<NetworkSpeedUnit> units) {
+    final Set<NetworkSpeedUnit> normalized = parse(
+      units.map((NetworkSpeedUnit unit) => unit.id).join(','),
+    );
+    if (normalized.contains(NetworkSpeedUnit.auto)) {
+      return NetworkSpeedUnit.auto.id;
+    }
+    return kNetworkSpeedUnitValues
+        .where(
+          (NetworkSpeedUnit unit) =>
+              unit != NetworkSpeedUnit.auto && normalized.contains(unit),
+        )
+        .map((NetworkSpeedUnit unit) => unit.id)
+        .join(',');
+  }
+
+  static bool usesAuto(Set<NetworkSpeedUnit> units) {
+    return parse(encode(units)).contains(NetworkSpeedUnit.auto);
+  }
+
+  static bool equals(Set<NetworkSpeedUnit> left, Set<NetworkSpeedUnit> right) {
+    return encode(left) == encode(right);
+  }
+}

--- a/lib/platform/livebridge_platform.dart
+++ b/lib/platform/livebridge_platform.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import '../models/app_models.dart';
+import '../models/network_speed_models.dart';
 
 class LiveBridgePlatform {
   static const MethodChannel _channel = MethodChannel('livebridge/platform');
@@ -59,6 +60,30 @@ class LiveBridgePlatform {
       _askBool('getTextProgressEnabled');
   static Future<bool> setTextProgressEnabled(bool value) =>
       _askBool('setTextProgressEnabled', {'value': value});
+  static Future<NetworkSpeedSettings> getNetworkSpeedSettings() async {
+    final Map<dynamic, dynamic>? res = await _channel
+        .invokeMethod<Map<dynamic, dynamic>>('getNetworkSpeedSettings');
+    final Map<String, dynamic> data = res == null
+        ? const <String, dynamic>{}
+        : Map<String, dynamic>.from(res);
+    return NetworkSpeedSettings.fromMap(data);
+  }
+
+  static Future<bool> setNetworkSpeedEnabled(bool value) =>
+      _askBool('setNetworkSpeedEnabled', {'value': value});
+  static Future<bool> setNetworkSpeedDisplayMode(String value) =>
+      _askBool('setNetworkSpeedDisplayMode', {'value': value});
+  static Future<bool> setNetworkSpeedUploadPrefix(String value) =>
+      _askBool('setNetworkSpeedUploadPrefix', {'value': value});
+  static Future<bool> setNetworkSpeedDownloadPrefix(String value) =>
+      _askBool('setNetworkSpeedDownloadPrefix', {'value': value});
+  static Future<bool> setNetworkSpeedPrioritizeUploadSpeed(bool value) =>
+      _askBool('setNetworkSpeedPrioritizeUploadSpeed', {'value': value});
+  static Future<bool> setNetworkSpeedChipBackgroundDisabled(bool value) =>
+      _askBool('setNetworkSpeedChipBackgroundDisabled', {'value': value});
+  static Future<bool> setNetworkSpeedUnit(String value) =>
+      _askBool('setNetworkSpeedUnit', {'value': value});
+
   static Future<bool> getConverterEnabled() => _askBool('getConverterEnabled');
   static Future<bool> setConverterEnabled(bool value) =>
       _askBool('setConverterEnabled', {'value': value});

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -9,8 +9,10 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../l10n/app_strings.dart';
 import '../models/app_models.dart';
+import '../models/network_speed_models.dart';
 import '../platform/livebridge_platform.dart';
 import '../utils/livebridge_haptics.dart';
+import '../widgets/network_speed_section.dart';
 import '../widgets/shared_widgets.dart';
 import 'app_presentation_settings_page.dart';
 
@@ -89,6 +91,7 @@ class _LiveBridgeHomePageState extends State<LiveBridgeHomePage>
   bool _previewAppsLoading = false;
   PackageMode _packageMode = PackageMode.all;
   PackageMode _otpPackageMode = PackageMode.all;
+  NetworkSpeedSettings _networkSpeedSettings = const NetworkSpeedSettings();
   late final AnimationController _masterBlockedShakeController;
   late final Animation<double> _masterBlockedShakeOffset;
   bool _masterBlockedHapticInProgress = false;
@@ -222,6 +225,8 @@ class _LiveBridgeHomePageState extends State<LiveBridgeHomePage>
           await LiveBridgePlatform.getSmartExternalDevicesEnabled();
       final bool smartVpnEnabled =
           await LiveBridgePlatform.getSmartVpnEnabled();
+      final NetworkSpeedSettings networkSpeedSettings =
+          await LiveBridgePlatform.getNetworkSpeedSettings();
       final bool otpDetectionEnabled =
           await LiveBridgePlatform.getOtpDetectionEnabled();
       final bool otpAutoCopyEnabled =
@@ -310,6 +315,7 @@ class _LiveBridgeHomePageState extends State<LiveBridgeHomePage>
         _smartWeatherEnabled = smartWeatherEnabled;
         _smartExternalDevicesEnabled = smartExternalDevicesEnabled;
         _smartVpnEnabled = smartVpnEnabled;
+        _networkSpeedSettings = networkSpeedSettings;
         _otpDetectionEnabled = otpDetectionEnabled;
         _otpAutoCopyEnabled = otpAutoCopyEnabled;
         _updateChecksEnabled = updateChecksEnabled;
@@ -785,6 +791,49 @@ class _LiveBridgeHomePageState extends State<LiveBridgeHomePage>
     await LiveBridgePlatform.setSmartVpnEnabled(value);
   }
 
+  Future<void> _setNetworkSpeedSettings(NetworkSpeedSettings next) async {
+    final NetworkSpeedSettings previous = _networkSpeedSettings;
+    setState(() => _networkSpeedSettings = next);
+
+    try {
+      if (previous.enabled != next.enabled) {
+        await LiveBridgePlatform.setNetworkSpeedEnabled(next.enabled);
+      }
+      if (previous.displayMode != next.displayMode) {
+        await LiveBridgePlatform.setNetworkSpeedDisplayMode(
+          next.displayMode.id,
+        );
+      }
+      if (previous.uploadPrefix != next.uploadPrefix) {
+        await LiveBridgePlatform.setNetworkSpeedUploadPrefix(next.uploadPrefix);
+      }
+      if (previous.downloadPrefix != next.downloadPrefix) {
+        await LiveBridgePlatform.setNetworkSpeedDownloadPrefix(
+          next.downloadPrefix,
+        );
+      }
+      if (previous.prioritizeUploadSpeed != next.prioritizeUploadSpeed) {
+        await LiveBridgePlatform.setNetworkSpeedPrioritizeUploadSpeed(
+          next.prioritizeUploadSpeed,
+        );
+      }
+      if (previous.chipBackgroundDisabled != next.chipBackgroundDisabled) {
+        await LiveBridgePlatform.setNetworkSpeedChipBackgroundDisabled(
+          next.chipBackgroundDisabled,
+        );
+      }
+      if (!NetworkSpeedUnitSelection.equals(previous.units, next.units)) {
+        await LiveBridgePlatform.setNetworkSpeedUnit(
+          NetworkSpeedUnitSelection.encode(next.units),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        _snack(AppStrings.of(context).saveFailed);
+      }
+    }
+  }
+
   Future<void> _setOtpDetection(bool value) async {
     LiveBridgeHaptics.toggle(value);
     setState(() => _otpDetectionEnabled = value);
@@ -1248,6 +1297,7 @@ class _LiveBridgeHomePageState extends State<LiveBridgeHomePage>
         'smart_weather_enabled': _smartWeatherEnabled,
         'smart_external_devices_enabled': _smartExternalDevicesEnabled,
         'smart_vpn_enabled': _smartVpnEnabled,
+        'network_speed': _networkSpeedSettings.toJson(),
         'otp_detection_enabled': _otpDetectionEnabled,
         'otp_auto_copy_enabled': _otpAutoCopyEnabled,
         'aosp_cutting_enabled': _aospCuttingEnabled,
@@ -1415,6 +1465,8 @@ class _LiveBridgeHomePageState extends State<LiveBridgeHomePage>
                     _buildRulesCard(s),
                     const SizedBox(height: 24),
                     _buildSmartCard(s),
+                    const SizedBox(height: 24),
+                    _buildNetworkSpeedCard(s),
                     const SizedBox(height: 24),
                     _buildOtpCard(s),
                     const SizedBox(height: 24),
@@ -2385,6 +2437,21 @@ class _LiveBridgeHomePageState extends State<LiveBridgeHomePage>
             activeThumbColor: Theme.of(context).colorScheme.primary,
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildNetworkSpeedCard(AppStrings s) {
+    return _sectionPanel(
+      sectionId: 'network_speed',
+      title: s.networkSpeedTitle,
+      icon: Icons.speed_rounded,
+      child: NetworkSpeedSection(
+        settings: _networkSpeedSettings,
+        masterEnabled: _masterSwitchValue,
+        onChanged: (NetworkSpeedSettings next) {
+          unawaited(_setNetworkSpeedSettings(next));
+        },
       ),
     );
   }

--- a/lib/widgets/network_speed_section.dart
+++ b/lib/widgets/network_speed_section.dart
@@ -1,0 +1,750 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/app_strings.dart';
+import '../models/network_speed_models.dart';
+import '../utils/livebridge_haptics.dart';
+
+class NetworkSpeedSection extends StatelessWidget {
+  const NetworkSpeedSection({
+    super.key,
+    required this.settings,
+    required this.masterEnabled,
+    required this.onChanged,
+  });
+
+  final NetworkSpeedSettings settings;
+  final bool masterEnabled;
+  final ValueChanged<NetworkSpeedSettings> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+    final AppStrings s = AppStrings.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          s.networkSpeedSubtitle,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 16),
+        SwitchListTile.adaptive(
+          value: settings.enabled,
+          onChanged: (bool value) {
+            LiveBridgeHaptics.toggle(value);
+            onChanged(settings.copyWith(enabled: value));
+          },
+          title: Text(
+            s.networkSpeedEnabledTitle,
+            style: const TextStyle(fontWeight: FontWeight.w600),
+          ),
+          subtitle: Text(
+            masterEnabled
+                ? s.networkSpeedEnabledSubtitle
+                : s.networkSpeedEnabledMasterOffSubtitle,
+            style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 13),
+          ),
+          contentPadding: EdgeInsets.zero,
+          activeThumbColor: colorScheme.primary,
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 16),
+          child: Divider(height: 1),
+        ),
+        AnimatedOpacity(
+          duration: const Duration(milliseconds: 200),
+          opacity: settings.enabled ? 1 : 0.4,
+          child: IgnorePointer(
+            ignoring: !settings.enabled,
+            child: Column(
+              children: <Widget>[
+                _NetworkSpeedDisplayModeDropdown(
+                  label: s.networkSpeedDisplayContentTitle,
+                  value: settings.displayMode,
+                  optionLabelBuilder: (NetworkSpeedDisplayMode mode) {
+                    switch (mode) {
+                      case NetworkSpeedDisplayMode.total:
+                        return s.networkSpeedDisplayModeTotal;
+                      case NetworkSpeedDisplayMode.uploadOnly:
+                        return s.networkSpeedDisplayModeUploadOnly;
+                      case NetworkSpeedDisplayMode.downloadOnly:
+                        return s.networkSpeedDisplayModeDownloadOnly;
+                    }
+                  },
+                  onChanged: (NetworkSpeedDisplayMode next) {
+                    if (next == settings.displayMode) {
+                      return;
+                    }
+                    LiveBridgeHaptics.selection();
+                    onChanged(settings.copyWith(displayMode: next));
+                  },
+                ),
+                const SizedBox(height: 12),
+                _NetworkSpeedActionTile(
+                  title: s.networkSpeedUploadPrefixLabel,
+                  value: s.networkSpeedCurrentValue(
+                    settings.uploadPrefix.replaceAll('\n', r'\n'),
+                  ),
+                  icon: Icons.north_rounded,
+                  onTap: () => _openPrefixSheet(
+                    context,
+                    title: s.networkSpeedUploadPrefixLabel,
+                    currentValue: settings.uploadPrefix,
+                    defaultValue: NetworkSpeedSettings.defaultUploadPrefix,
+                    hintText: s.networkSpeedPrefixEditorHint,
+                    onSaved: (String value) {
+                      onChanged(settings.copyWith(uploadPrefix: value));
+                    },
+                  ),
+                ),
+                const SizedBox(height: 12),
+                _NetworkSpeedActionTile(
+                  title: s.networkSpeedDownloadPrefixLabel,
+                  value: s.networkSpeedCurrentValue(
+                    settings.downloadPrefix.replaceAll('\n', r'\n'),
+                  ),
+                  icon: Icons.south_rounded,
+                  onTap: () => _openPrefixSheet(
+                    context,
+                    title: s.networkSpeedDownloadPrefixLabel,
+                    currentValue: settings.downloadPrefix,
+                    defaultValue: NetworkSpeedSettings.defaultDownloadPrefix,
+                    hintText: s.networkSpeedPrefixEditorHint,
+                    onSaved: (String value) {
+                      onChanged(settings.copyWith(downloadPrefix: value));
+                    },
+                  ),
+                ),
+                const SizedBox(height: 12),
+                _NetworkSpeedUnitDropdown(
+                  label: s.networkSpeedUnitTitle,
+                  values: settings.units,
+                  optionLabelBuilder: (NetworkSpeedUnit unit) {
+                    switch (unit) {
+                      case NetworkSpeedUnit.auto:
+                        return s.networkSpeedUnitAuto;
+                      case NetworkSpeedUnit.bytes:
+                        return 'B/s';
+                      case NetworkSpeedUnit.kilobytes:
+                        return 'KB/s';
+                      case NetworkSpeedUnit.megabytes:
+                        return 'MB/s';
+                      case NetworkSpeedUnit.gigabytes:
+                        return 'GB/s';
+                    }
+                  },
+                  onChanged: (Set<NetworkSpeedUnit> values) {
+                    if (NetworkSpeedUnitSelection.equals(
+                      values,
+                      settings.units,
+                    )) {
+                      return;
+                    }
+                    onChanged(settings.copyWith(units: values));
+                  },
+                ),
+                const SizedBox(height: 12),
+                SwitchListTile.adaptive(
+                  value: settings.prioritizeUploadSpeed,
+                  onChanged: (bool value) {
+                    LiveBridgeHaptics.toggle(value);
+                    onChanged(settings.copyWith(prioritizeUploadSpeed: value));
+                  },
+                  title: Text(
+                    s.networkSpeedPrioritizeUploadTitle,
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  subtitle: Text(
+                    s.networkSpeedPrioritizeUploadSubtitle,
+                    style: TextStyle(
+                      color: colorScheme.onSurfaceVariant,
+                      fontSize: 13,
+                    ),
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                  activeThumbColor: colorScheme.primary,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _openPrefixSheet(
+    BuildContext context, {
+    required String title,
+    required String currentValue,
+    required String defaultValue,
+    required String hintText,
+    required ValueChanged<String> onSaved,
+  }) async {
+    final String? selected = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(32)),
+      ),
+      builder: (BuildContext context) => _NetworkSpeedPrefixSheet(
+        title: title,
+        initialValue: currentValue,
+        defaultValue: defaultValue,
+        hintText: hintText,
+        resetLabel: AppStrings.of(context).resetToDefault,
+        saveLabel: AppStrings.of(context).save,
+      ),
+    );
+
+    if (selected == null || selected == currentValue) {
+      return;
+    }
+
+    onSaved(selected);
+  }
+}
+
+class _NetworkSpeedDisplayModeDropdown extends StatelessWidget {
+  const _NetworkSpeedDisplayModeDropdown({
+    required this.label,
+    required this.value,
+    required this.optionLabelBuilder,
+    required this.onChanged,
+  });
+
+  final String label;
+  final NetworkSpeedDisplayMode value;
+  final String Function(NetworkSpeedDisplayMode mode) optionLabelBuilder;
+  final ValueChanged<NetworkSpeedDisplayMode> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final bool isLight = colorScheme.brightness == Brightness.light;
+    final Color fieldColor = isLight
+        ? Colors.white
+        : colorScheme.surfaceContainerLow;
+    final Color menuColor = isLight
+        ? Colors.white
+        : colorScheme.surfaceContainer;
+    final Color borderColor = colorScheme.primary.withValues(
+      alpha: isLight ? 0.5 : 0.65,
+    );
+
+    return DropdownButtonFormField<NetworkSpeedDisplayMode>(
+      initialValue: value,
+      onTap: LiveBridgeHaptics.openSurface,
+      onChanged: (NetworkSpeedDisplayMode? next) {
+        if (next == null) {
+          return;
+        }
+        onChanged(next);
+      },
+      isExpanded: true,
+      icon: Icon(
+        Icons.keyboard_arrow_down_rounded,
+        color: colorScheme.onSurfaceVariant,
+      ),
+      dropdownColor: menuColor,
+      borderRadius: BorderRadius.circular(24),
+      decoration: InputDecoration(
+        labelText: label,
+        labelStyle: TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
+          color: colorScheme.onSurfaceVariant,
+        ),
+        filled: true,
+        fillColor: fieldColor,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(20),
+          borderSide: BorderSide(color: borderColor, width: 1.2),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(20),
+          borderSide: BorderSide(color: borderColor, width: 1.2),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(20),
+          borderSide: BorderSide(color: colorScheme.primary, width: 1.8),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 20,
+          vertical: 16,
+        ),
+      ),
+      items: NetworkSpeedDisplayMode.values.map((NetworkSpeedDisplayMode mode) {
+        return DropdownMenuItem<NetworkSpeedDisplayMode>(
+          value: mode,
+          child: Text(
+            optionLabelBuilder(mode),
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _NetworkSpeedActionTile extends StatelessWidget {
+  const _NetworkSpeedActionTile({
+    required this.title,
+    required this.value,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String title;
+  final String value;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: () {
+          LiveBridgeHaptics.openSurface();
+          onTap();
+        },
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            color: colorScheme.primaryContainer.withValues(alpha: 0.38),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Row(
+            children: <Widget>[
+              Container(
+                width: 34,
+                height: 34,
+                decoration: BoxDecoration(
+                  color: colorScheme.primary.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(icon, size: 18, color: colorScheme.primary),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 15,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      value,
+                      style: TextStyle(
+                        color: colorScheme.onSurfaceVariant,
+                        fontSize: 13,
+                        height: 1.2,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Icon(
+                Icons.keyboard_arrow_right_rounded,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NetworkSpeedUnitDropdown extends StatefulWidget {
+  const _NetworkSpeedUnitDropdown({
+    required this.label,
+    required this.values,
+    required this.optionLabelBuilder,
+    required this.onChanged,
+  });
+
+  final String label;
+  final Set<NetworkSpeedUnit> values;
+  final String Function(NetworkSpeedUnit unit) optionLabelBuilder;
+  final ValueChanged<Set<NetworkSpeedUnit>> onChanged;
+
+  @override
+  State<_NetworkSpeedUnitDropdown> createState() =>
+      _NetworkSpeedUnitDropdownState();
+}
+
+class _NetworkSpeedUnitDropdownState extends State<_NetworkSpeedUnitDropdown> {
+  final MenuController _menuController = MenuController();
+  late Set<NetworkSpeedUnit> _draftValues;
+  late Set<NetworkSpeedUnit> _committedValues;
+  bool _menuOpen = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _draftValues = _normalize(widget.values);
+    _committedValues = _normalize(widget.values);
+  }
+
+  @override
+  void didUpdateWidget(covariant _NetworkSpeedUnitDropdown oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_menuOpen) {
+      return;
+    }
+
+    final Set<NetworkSpeedUnit> normalized = _normalize(widget.values);
+    if (!_sameSelection(normalized, _draftValues)) {
+      _draftValues = normalized;
+      _committedValues = normalized;
+    }
+  }
+
+  Set<NetworkSpeedUnit> _normalize(Set<NetworkSpeedUnit> values) {
+    return Set<NetworkSpeedUnit>.from(
+      NetworkSpeedUnitSelection.parse(
+        values.map((NetworkSpeedUnit unit) => unit.id).join(','),
+      ),
+    );
+  }
+
+  bool _sameSelection(Set<NetworkSpeedUnit> left, Set<NetworkSpeedUnit> right) {
+    return NetworkSpeedUnitSelection.equals(left, right);
+  }
+
+  void _toggleUnit(NetworkSpeedUnit unit) {
+    final bool checked = _draftValues.contains(unit);
+    final Set<NetworkSpeedUnit> next;
+    if (checked) {
+      next = Set<NetworkSpeedUnit>.from(_draftValues)..remove(unit);
+    } else if (unit == NetworkSpeedUnit.auto) {
+      next = <NetworkSpeedUnit>{NetworkSpeedUnit.auto};
+    } else {
+      next = Set<NetworkSpeedUnit>.from(_draftValues)
+        ..remove(NetworkSpeedUnit.auto)
+        ..add(unit);
+    }
+    setState(() => _draftValues = _normalize(next));
+  }
+
+  void _commitSelection() {
+    final Set<NetworkSpeedUnit> next = _normalize(_draftValues);
+    if (_sameSelection(next, _committedValues)) {
+      return;
+    }
+    _committedValues = next;
+    widget.onChanged(next);
+  }
+
+  void _toggleMenu() {
+    if (_menuController.isOpen) {
+      _menuController.close();
+      return;
+    }
+    LiveBridgeHaptics.openSurface();
+    _menuController.open();
+  }
+
+  String _summaryLabel() {
+    if (_draftValues.contains(NetworkSpeedUnit.auto)) {
+      return widget.optionLabelBuilder(NetworkSpeedUnit.auto);
+    }
+
+    return kNetworkSpeedUnitValues
+        .where(
+          (NetworkSpeedUnit unit) =>
+              unit != NetworkSpeedUnit.auto && _draftValues.contains(unit),
+        )
+        .map(widget.optionLabelBuilder)
+        .join(', ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final bool isLight = colorScheme.brightness == Brightness.light;
+    final Color fieldColor = isLight
+        ? Colors.white
+        : colorScheme.surfaceContainerLow;
+    final Color menuColor = isLight
+        ? Colors.white
+        : colorScheme.surfaceContainer;
+    final Color borderColor = colorScheme.primary.withValues(
+      alpha: isLight ? 0.5 : 0.65,
+    );
+
+    return MenuAnchor(
+      controller: _menuController,
+      consumeOutsideTap: true,
+      crossAxisUnconstrained: false,
+      style: MenuStyle(
+        backgroundColor: WidgetStatePropertyAll<Color>(menuColor),
+        shape: WidgetStatePropertyAll<OutlinedBorder>(
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        ),
+        side: WidgetStatePropertyAll<BorderSide>(
+          BorderSide(color: borderColor, width: 1.2),
+        ),
+        padding: const WidgetStatePropertyAll<EdgeInsets>(EdgeInsets.zero),
+      ),
+      onOpen: () => setState(() => _menuOpen = true),
+      onClose: () {
+        if (mounted) {
+          setState(() => _menuOpen = false);
+        }
+        _commitSelection();
+      },
+      menuChildren: <Widget>[
+        SizedBox(
+          width: 320,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                for (final NetworkSpeedUnit unit in kNetworkSpeedUnitValues)
+                  _NetworkSpeedUnitMenuRow(
+                    title: widget.optionLabelBuilder(unit),
+                    checked: _draftValues.contains(unit),
+                    onTap: () {
+                      LiveBridgeHaptics.selection();
+                      _toggleUnit(unit);
+                    },
+                  ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton.tonalIcon(
+                    onPressed: _menuController.close,
+                    icon: const Icon(Icons.check_rounded, size: 18),
+                    label: Text(
+                      MaterialLocalizations.of(context).okButtonLabel,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+      builder:
+          (BuildContext context, MenuController controller, Widget? child) {
+            return Material(
+              color: Colors.transparent,
+              child: InkWell(
+                borderRadius: BorderRadius.circular(20),
+                onTap: _toggleMenu,
+                child: InputDecorator(
+                  isEmpty: false,
+                  decoration: InputDecoration(
+                    labelText: widget.label,
+                    labelStyle: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                    filled: true,
+                    fillColor: fieldColor,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(20),
+                      borderSide: BorderSide(color: borderColor, width: 1.2),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(20),
+                      borderSide: BorderSide(color: borderColor, width: 1.2),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(20),
+                      borderSide: BorderSide(
+                        color: colorScheme.primary,
+                        width: 1.8,
+                      ),
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 16,
+                    ),
+                    suffixIcon: Icon(
+                      _menuOpen
+                          ? Icons.keyboard_arrow_up_rounded
+                          : Icons.keyboard_arrow_down_rounded,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  child: Text(
+                    _summaryLabel(),
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+    );
+  }
+}
+
+class _NetworkSpeedUnitMenuRow extends StatelessWidget {
+  const _NetworkSpeedUnitMenuRow({
+    required this.title,
+    required this.checked,
+    required this.onTap,
+  });
+
+  final String title;
+  final bool checked;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+          child: Row(
+            children: <Widget>[
+              Checkbox(
+                value: checked,
+                onChanged: (_) => onTap(),
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: checked ? FontWeight.w700 : FontWeight.w500,
+                    color: checked
+                        ? colorScheme.onSurface
+                        : colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NetworkSpeedPrefixSheet extends StatefulWidget {
+  const _NetworkSpeedPrefixSheet({
+    required this.title,
+    required this.initialValue,
+    required this.defaultValue,
+    required this.hintText,
+    required this.resetLabel,
+    required this.saveLabel,
+  });
+
+  final String title;
+  final String initialValue;
+  final String defaultValue;
+  final String hintText;
+  final String resetLabel;
+  final String saveLabel;
+
+  @override
+  State<_NetworkSpeedPrefixSheet> createState() =>
+      _NetworkSpeedPrefixSheetState();
+}
+
+class _NetworkSpeedPrefixSheetState extends State<_NetworkSpeedPrefixSheet> {
+  late final TextEditingController _controller = TextEditingController(
+    text: widget.initialValue,
+  );
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 24,
+          right: 24,
+          top: 8,
+          bottom: 24 + MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              widget.title,
+              style: Theme.of(
+                context,
+              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+            ),
+            const SizedBox(height: 20),
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              decoration: InputDecoration(
+                hintText: widget.hintText,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(18),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: () {
+                    LiveBridgeHaptics.warning();
+                    Navigator.of(context).pop(widget.defaultValue);
+                  },
+                  icon: const Icon(Icons.refresh_rounded),
+                  label: Text(widget.resetLabel),
+                ),
+                const SizedBox(width: 12),
+                FilledButton.icon(
+                  onPressed: () {
+                    LiveBridgeHaptics.confirm();
+                    Navigator.of(context).pop(_controller.text);
+                  },
+                  icon: const Icon(Icons.check_rounded),
+                  label: Text(widget.saveLabel),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/shared_widgets.dart
+++ b/lib/widgets/shared_widgets.dart
@@ -347,6 +347,35 @@ class LiveBridgeChoiceSelector<T> extends StatelessWidget {
   }
 }
 
+class LiveBridgeMultiChoiceSelector<T> extends StatelessWidget {
+  const LiveBridgeMultiChoiceSelector({
+    super.key,
+    required this.values,
+    required this.options,
+    required this.onToggle,
+  });
+
+  final Set<T> values;
+  final List<SelectorOption<T>> options;
+  final ValueChanged<T> onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        for (int index = 0; index < options.length; index++) ...<Widget>[
+          _ChoiceCard<T>(
+            option: options[index],
+            selected: values.contains(options[index].value),
+            onTap: () => onToggle(options[index].value),
+          ),
+          if (index != options.length - 1) const SizedBox(height: 10),
+        ],
+      ],
+    );
+  }
+}
+
 class LiveBridgeToggleSelector<T> extends StatelessWidget {
   const LiveBridgeToggleSelector({
     super.key,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -172,18 +172,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- add a dedicated Network speed settings section with localized controls for display mode, prefixes, unit selection, and upload priority
- add Android network speed foreground service/runtime, platform bridge wiring, persistence, boot restore, and chip icon resources
- align the network speed live notification path and related strings/styles with the current app behavior

## Testing
- flutter build apk --release --build-number 2040
- adb install -r build/app/outputs/flutter-apk/app-release.apk
- adb dumpsys notification --noredact
