### PR TITLE
Fix docs polling cadence and counter animation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -695,7 +695,7 @@
         }
         to {
           transform: translateY(-115%);
-          opacity: 0.28;
+          opacity: 0;
         }
       }
 
@@ -1346,10 +1346,10 @@
       const rawAssetBase = `https://raw.githubusercontent.com/${owner}/${repo}/main/assets`;
       const numberFormat = new Intl.NumberFormat("en-US");
       const defaultRecommendedBuild = "armv8a";
-      const liveRefreshMinMs = 5200;
-      const liveRefreshJitterMs = 900;
-      const liveRefreshHiddenMs = 15000;
+      const liveRefreshMinMs = 30000;
+      const liveRefreshJitterMs = 1000;
       const liveRefreshErrorMs = 30000;
+      const liveCounterAnimationDurationMs = 520;
       const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
       const counterNumberPattern = /\d[\d,]*/g;
       let releaseDataPollTimer = null;
@@ -1396,7 +1396,7 @@
         clearReleaseDataRefreshTimer();
         releaseDataPollTimer = window.setTimeout(() => {
           if (document.hidden) {
-            scheduleReleaseDataRefresh(liveRefreshHiddenMs);
+            scheduleReleaseDataRefresh(getNextLiveRefreshDelay());
             return;
           }
           loadReleaseData({ preserveOnError: true });
@@ -1433,6 +1433,13 @@
         return node;
       }
 
+      function createCounterGlyph(char) {
+        const glyph = document.createElement("span");
+        glyph.className = "live-counter-glyph";
+        glyph.textContent = char;
+        return glyph;
+      }
+
       function createCounterChar(char, { previousChar = "", animate = false } = {}) {
         const node = document.createElement("span");
         const safeChar = char === " " ? "\u00A0" : char;
@@ -1454,15 +1461,22 @@
           newFace.className = "live-counter-face live-counter-face--new";
           newFace.textContent = safeChar;
 
+          let finalized = false;
+          const finalize = () => {
+            if (finalized) return;
+            finalized = true;
+            node.classList.remove("is-flipping");
+            node.replaceChildren(createCounterGlyph(safeChar));
+          };
+
           stack.append(oldFace, newFace);
           node.append(stack);
+          newFace.addEventListener("animationend", finalize, { once: true });
+          window.setTimeout(finalize, liveCounterAnimationDurationMs + 80);
           return node;
         }
 
-        const glyph = document.createElement("span");
-        glyph.className = "live-counter-glyph";
-        glyph.textContent = safeChar;
-        node.append(glyph);
+        node.append(createCounterGlyph(safeChar));
         return node;
       }
 
@@ -1493,6 +1507,21 @@
         return node;
       }
 
+      function hasStableCounterShape(previousSegments, nextSegments) {
+        if (!previousSegments.length || previousSegments.length !== nextSegments.length) {
+          return false;
+        }
+
+        return nextSegments.every((segment, index) => {
+          const previousSegment = previousSegments[index];
+          if (!previousSegment || previousSegment.type !== segment.type) {
+            return false;
+          }
+
+          return segment.type === "number" || previousSegment.value === segment.value;
+        });
+      }
+
       function renderCounterText(element, nextText, { animate = true } = {}) {
         if (!element) return;
 
@@ -1509,15 +1538,17 @@
         }
 
         const nextSegments = splitCounterSegments(nextValue);
-        const previousNumberSegments = splitCounterSegments(previousValue)
+        const previousSegments = splitCounterSegments(previousValue);
+        const canAnimateDigits = Boolean(
+          animate &&
+          previousValue &&
+          !prefersReducedMotion.matches &&
+          hasStableCounterShape(previousSegments, nextSegments)
+        );
+        const previousNumberSegments = previousSegments
           .filter((segment) => segment.type === "number")
           .map((segment) => segment.value);
         const fragment = document.createDocumentFragment();
-        const shouldAnimate = Boolean(
-          animate &&
-          previousValue &&
-          !prefersReducedMotion.matches
-        );
         let numberSegmentIndex = 0;
 
         nextSegments.forEach((segment) => {
@@ -1530,7 +1561,7 @@
             createCounterNumberSegment(
               segment.value,
               previousNumberSegments[numberSegmentIndex] || "",
-              shouldAnimate
+              canAnimateDigits
             )
           );
           numberSegmentIndex += 1;
@@ -1759,9 +1790,7 @@
         const statusEl = document.getElementById("stat-status");
         const bannerTitleEl = document.getElementById("release-banner-title");
         const bannerCopyEl = document.getElementById("release-banner-copy");
-        let nextRefreshDelay = document.hidden
-          ? liveRefreshHiddenMs
-          : getNextLiveRefreshDelay();
+        let nextRefreshDelay = getNextLiveRefreshDelay();
 
         releaseDataRequestInFlight = true;
 


### PR DESCRIPTION
## Summary
- slow GitHub release polling on the docs site down to ~30 seconds with small jitter
- keep digit flip animation only for stable numeric updates and skip it for text-shape changes
- finalize flipped digits back into static glyphs so counters do not get stuck mid-animation

## Testing
- validated the inline script parses successfully
- verified in headless Chromium that the docs page issues the second GitHub API request after ~31 seconds
- verified in the browser that flipped digits collapse back to static text and text-shape changes render without stuck animation