### PR TITLE
Add Português (Brasil) dictionary support

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,26 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,4 +46,4 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build --android-skip-build-dependency-validation

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,32 +8,42 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: android
 
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
-    - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v6
-      with:
-        gradle-version: '9.4.1'
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
 
-    - name: Generate Gradle wrapper
-      run: gradle wrapper --gradle-version 9.4.1
+      - name: Create local.properties
+        run: |
+          echo "sdk.dir=$ANDROID_HOME" > local.properties
+          echo "flutter.sdk=$FLUTTER_ROOT" >> local.properties
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x ./gradlew
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '9.4.1'
 
-    - name: Build with Gradle
-      run: ./gradlew build
+      - name: Generate Gradle wrapper
+        run: gradle wrapper --gradle-version 9.4.1
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,14 +17,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: gradle
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        gradle-version: '9.4.1'
+
+    - name: Generate Gradle wrapper
+      run: gradle wrapper --gradle-version 9.4.1
 
     - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      run: chmod +x ./gradlew
+
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+
 
     steps:
     - uses: actions/checkout@v4

--- a/android/app/src/main/assets/liveupdate_dictionary.json
+++ b/android/app/src/main/assets/liveupdate_dictionary.json
@@ -21,7 +21,16 @@
         "swiggy",
         "blinkit",
         "instamart",
-        "bigbasket"
+        "bigbasket",
+        "ifood",
+        "i.food",
+        "aiqfome",
+        "rappi",
+        "99food",
+        "food to save",
+        "delivery much",
+        "anota ai",
+        "menu direto"
       ],
       "text_triggers": [
         "заказ",
@@ -46,7 +55,23 @@
         "送餐員",
         "餐点",
         "餐點",
-        "配送"
+        "配送",
+        "pedido",
+        "entrega",
+        "entregador",
+        "motoboy",
+        "restaurante",
+        "lanche",
+        "comida",
+        "delivery",
+        "saiu para entrega",
+        "a caminho",
+        "preparando",
+        "pronto para retirada",
+        "retirada",
+        "retirar",
+        "cozinha",
+        "pagamento aprovado"
       ],
       "exclude_patterns": [
         "(с дн[её]м рождения|happy birthday|birthday|生日快乐|生日快樂)",
@@ -55,7 +80,12 @@
         "(cart|basket|checkout|complete\\s+(?:your\\s+)?checkout|finish\\s+(?:your\\s+)?order|корзин|заверш(?:ите|ить)\\s+оформлени|оформите\\s+заказ|перейдите\\s+к\\s+оформлени|продолж(?:ите|ить)\\s+оформлени)",
         "(you'?ll\\s+get\\s+an\\s+alert[^\\n]{0,80}(?:at\\s+your\\s+door|delivered)|keep\\s+your\\s+phone\\s+nearby\\s+until\\s+it'?s\\s+delivered|until\\s+it'?s\\s+delivered)",
         "(при\\s+заказе\\s+от\\s*\\d|order\\s+from\\s*\\d|满\\d+减|滿\\d+減)",
-        "(почт[аы]\\s+росси|посыл(?:к|ок)|маркетплейс|отделени[ея]|трек-?номер|tracking|shipment|parcel|пункт\\s*выдачи|取件码|取件碼|快递|快遞|驿站|驛站|包裹|收发室|收發室)"
+        "(почт[аы]\\s+росси|посыл(?:к|ок)|маркетплейс|отделени[ея]|трек-?номер|tracking|shipment|parcel|пункт\\s*выдачи|取件码|取件碼|快递|快遞|驿站|驛站|包裹|收发室|收發室)",
+        "(feliz\\s+anivers[áa]rio|parab[ée]ns)",
+        "(cupom|promo[cç][aã]o|promocional|desconto|cashback|oferta|ganhe\\s+\\d+%|\\d+%\\s*(?:off|de\\s+desconto)|frete\\s+gr[áa]tis|voucher|benef[íi]cio)",
+        "(pagamento\\s*(?:falhou|recusado|n[aã]o\\s+aprovado|n[aã]o\\s+conclu[ií]do)|pedido\\s+cancelado|cancelamento|estorno|reembolso)",
+        "(carrinho|sacola|checkout|finalize\\s+(?:seu\\s+)?pedido|conclua\\s+(?:seu\\s+)?pedido|continuar\\s+compra)",
+        "(correios|encomenda|pacote|rastreamento|c[óo]digo\\s+de\\s+rastreio|objeto\\s+postal|retirada\\s+em\\s+ag[êe]ncia|marketplace)"
       ],
       "signals": [
         {
@@ -77,6 +107,26 @@
         {
           "stage": 0,
           "pattern": "(заказ[^\\n]*(принят|создан|оформлен(?:а|о|ы)?\\b|подтвержд[её]н|оплачен)|order[^\\n]*(received|accepted|confirmed|created|placed|paid)|оплат[аы][^\\n]*(прошла|подтверждена|успешна|принята)|payment[^\\n]*(successful|confirmed|received|accepted)|订单已接|訂單已接|已付款|支付成功|订单已确认|訂單已確認|下单成功|下單成功|已建立)"
+        },
+        {
+          "stage": 4,
+          "pattern": "(pedido\\s+(?:entregue|finalizado|conclu[ií]do)|entrega\\s+(?:realizada|conclu[ií]da)|bom\\s+apetite|aproveite\\s+(?:seu\\s+)?pedido|obrigado\\s+por\\s+pedir)"
+        },
+        {
+          "stage": 3,
+          "pattern": "((?:seu\\s+)?pedido\\s+(?:saiu\\s+para\\s+entrega|est[aá]\\s+a\\s+caminho|est[aá]\\s+indo\\s+at[eé]\\s+voc[eê])|entregador[^\\n]*(?:a\\s+caminho|chegando|pr[óo]ximo|retirou|pegou)|motoboy[^\\n]*(?:a\\s+caminho|chegando|pr[óo]ximo|retirou|pegou))"
+        },
+        {
+          "stage": 2,
+          "pattern": "((?:seu\\s+)?pedido[^\\n]{0,50}(?:pronto|preparado|embalado|aguardando\\s+(?:retirada|entregador)|pronto\\s+para\\s+(?:retirada|entrega))|retire\\s+(?:seu\\s+)?pedido|pronto\\s+para\\s+retirar)"
+        },
+        {
+          "stage": 1,
+          "pattern": "((?:seu\\s+)?pedido[^\\n]{0,50}(?:est[aá]\\s+sendo\\s+preparado|est[aá]\\s+em\\s+preparo|em\\s+preparo|na\\s+cozinha|come[cç]ou\\s+a\\s+ser\\s+preparado)|preparando\\s+(?:seu\\s+)?pedido)"
+        },
+        {
+          "stage": 0,
+          "pattern": "((?:seu\\s+)?pedido[^\\n]{0,50}(?:recebido|confirmado|aceito|criado|realizado|aprovado|pago)|pagamento[^\\n]{0,50}(?:aprovado|confirmado|recebido|realizado)|compra\\s+aprovada)"
         }
       ]
     },
@@ -91,7 +141,14 @@
         "yango",
         "yandex",
         "didi",
-        "grab"
+        "grab",
+        "99",
+        "99app",
+        "cabify",
+        "indrive",
+        "inDrive",
+        "mobizap",
+        "lady driver"
       ],
       "text_triggers": [
         "такси",
@@ -116,7 +173,19 @@
         "乘車",
         "网约车",
         "網約車",
-        "乘客"
+        "乘客",
+        "corrida",
+        "viagem",
+        "motorista",
+        "carro",
+        "placa",
+        "embarque",
+        "desembarque",
+        "partida",
+        "destino",
+        "chegando",
+        "chegou",
+        "solicitação de corrida"
       ],
       "signals": [
         {
@@ -138,6 +207,26 @@
         {
           "stage": 0,
           "pattern": "(поиск[^\\n]*водител|ищем[^\\n]*водител|searching for (a )?driver|finding driver|正在寻找司机|正在尋找司機|呼叫中|等待应答|等待應答|正在派单|正在派單|等待接驾|等待接駕)"
+        },
+        {
+          "stage": 4,
+          "pattern": "(viagem\\s+(?:finalizada|conclu[ií]da|encerrada)|corrida\\s+(?:finalizada|conclu[ií]da|encerrada)|voc[eê]\\s+chegou|chegamos\\s+ao\\s+destino|chegada\\s+ao\\s+destino)"
+        },
+        {
+          "stage": 3,
+          "pattern": "(viagem\\s+(?:iniciada|em\\s+andamento)|corrida\\s+(?:iniciada|em\\s+andamento)|aproveite\\s+(?:sua\\s+)?viagem|a\\s+caminho\\s+do\\s+destino)"
+        },
+        {
+          "stage": 2,
+          "pattern": "(motorista[^\\n]*(?:a\\s+caminho|chegando|pr[óo]ximo|chegou|j[aá]\\s+chegou|est[aá]\\s+no\\s+local)|carro[^\\n]*(?:a\\s+caminho|chegando|pr[óo]ximo)|v[aá]\\s+para\\s+o\\s+local\\s+de\\s+embarque)"
+        },
+        {
+          "stage": 1,
+          "pattern": "(motorista\\s+(?:encontrado|definido|a\\s+caminho|aceitou)|corrida\\s+aceita|viagem\\s+aceita|encontramos\\s+(?:um\\s+)?motorista)"
+        },
+        {
+          "stage": 0,
+          "pattern": "(procurando\\s+(?:um\\s+)?motorista|buscando\\s+(?:um\\s+)?motorista|encontrando\\s+(?:um\\s+)?motorista|solicita[cç][aã]o\\s+de\\s+corrida|chamando\\s+motorista)"
         }
       ]
     },
@@ -159,7 +248,10 @@
         "navi",
         "amap",
         "baidu.BaiduMap",
-        "citymapper"
+        "citymapper",
+        "mapas",
+        "rotas",
+        "gps"
       ],
       "text_triggers": [
         "маршрут",
@@ -216,12 +308,33 @@
         "向左",
         "往左",
         "向右",
-        "往右"
+        "往右",
+        "rota",
+        "rotas",
+        "navegação",
+        "navegacao",
+        "vire à esquerda",
+        "vire a esquerda",
+        "vire à direita",
+        "vire a direita",
+        "mantenha-se à esquerda",
+        "mantenha-se à direita",
+        "pegue a saída",
+        "retorno",
+        "rotatória",
+        "destino",
+        "chegou ao destino",
+        "siga em frente",
+        "continue",
+        "radar"
       ],
       "exclude_patterns": [
         "(с дн[её]м рождения|happy birthday|birthday|生日快乐|生日快樂)",
         "(дарим\\s+скидк|скидк[\\p{L}]*\\s*\\d+%|\\d+%\\s*(скидк|off)|акци[яи]|промокод|promo\\s*code|coupon|cash\\s*back|кэшб[еэ]к|红包|紅包|优惠|優惠|折扣|满减|滿減|返现|返現|促销|促銷|券|免運|免运费)",
-        "(вы получили это письмо|отписаться от рассыл|unsubscribe|newsletter|follow us|скачать приложение|download app)"
+        "(вы получили это письмо|отписаться от рассыл|unsubscribe|newsletter|follow us|скачать приложение|download app)",
+        "(feliz\\s+anivers[áa]rio|parab[ée]ns)",
+        "(cupom|promo[cç][aã]o|desconto|cashback|oferta|frete\\s+gr[áa]tis)",
+        "(voc[eê]\\s+recebeu\\s+este\\s+e-?mail|descadastrar|cancelar\\s+assinatura|newsletter|baixar\\s+app)"
       ],
       "signals": [
         {
@@ -239,6 +352,22 @@
         {
           "stage": 1,
           "pattern": "(маршрут построен|маршрут начат|navigation started|starting route|follow the route|route started|开始导航|開始導航|路线已规划|路線已規劃|准备出发|準備出發)"
+        },
+        {
+          "stage": 4,
+          "pattern": "(voc[eê]\\s+chegou|chegou\\s+ao\\s+destino|destino\\s+alcan[cç]ado|rota\\s+(?:finalizada|conclu[ií]da)|navega[cç][aã]o\\s+(?:finalizada|encerrada))"
+        },
+        {
+          "stage": 3,
+          "pattern": "(destino[^\\n]*(?:[àa]\\s+direita|[àa]\\s+esquerda)|quase\\s+l[aá]|aproximando-se\\s+do\\s+destino|voc[eê]\\s+est[aá]\\s+quase\\s+chegando)"
+        },
+        {
+          "stage": 2,
+          "pattern": "(em\\s+\\d+[\\d\\s.,]*(?:m|km|metros?|quil[oô]metros?)|vire\\s+(?:[àa]\\s+)?(?:esquerda|direita)|mantenha-se\\s+(?:[àa]\\s+)?(?:esquerda|direita)|pegue\\s+a\\s+sa[ií]da|fa[cç]a\\s+o\\s+retorno|entre\\s+na\\s+rotat[óo]ria|siga\\s+em\\s+frente|continue\\s+(?:em\\s+frente|reto)|radar\\s+[àa]\\s+frente)"
+        },
+        {
+          "stage": 1,
+          "pattern": "(rota\\s+(?:iniciada|calculada|tra[cç]ada|pronta)|navega[cç][aã]o\\s+iniciada|siga\\s+a\\s+rota|come[cç]ando\\s+a\\s+rota)"
         }
       ]
     },
@@ -254,7 +383,13 @@
         "dji",
         "wearable",
         "galaxywearable",
-        "miui"
+        "miui",
+        "fone",
+        "fone de ouvido",
+        "relógio",
+        "relogio",
+        "smartwatch",
+        "galaxy wearable"
       ],
       "text_triggers": [
         "camera",
@@ -282,12 +417,27 @@
         "耳机",
         "耳機",
         "手表",
-        "手錶"
+        "手錶",
+        "conectado",
+        "conectada",
+        "conectando",
+        "pareado",
+        "pareando",
+        "emparelhado",
+        "dispositivo",
+        "fone",
+        "fone de ouvido",
+        "relógio",
+        "relogio",
+        "smartwatch"
       ],
       "exclude_patterns": [
         "(с дн[её]м рождения|happy birthday|birthday|生日快乐|生日快樂)",
         "(дарим\\s+скидк|скидк[\\p{L}]*\\s*\\d+%|\\d+%\\s*(скидк|off)|акци[яи]|промокод|promo\\s*code|coupon|cash\\s*back|кэшб[еэ]к|红包|紅包|优惠|優惠|折扣|满减|滿減|返现|返現|促销|促銷|券|免運|免运费)",
-        "(hotspot|personal\\s+hotspot|tether(?:ing)?|wifi\\s+hotspot|точк[аеи]\\s+доступа|раздач[аи]\\s+интернета|клиент(?:ов|ы)?\\s+подключ(?:ен|ено|ены)?|\\b\\d+\\s+devices?\\b)"
+        "(hotspot|personal\\s+hotspot|tether(?:ing)?|wifi\\s+hotspot|точк[аеи]\\s+доступа|раздач[аи]\\s+интернета|клиент(?:ов|ы)?\\s+подключ(?:ен|ено|ены)?|\\b\\d+\\s+devices?\\b)",
+        "(feliz\\s+anivers[áa]rio|parab[ée]ns)",
+        "(cupom|promo[cç][aã]o|desconto|cashback|oferta)",
+        "(roteador|ponto\\s+de\\s+acesso|hotspot|compartilhamento\\s+de\\s+internet|\\b\\d+\\s+dispositivos?\\s+conectados?)"
       ],
       "signals": [
         {
@@ -297,6 +447,14 @@
         {
           "stage": 1,
           "pattern": "(connecting\\b|pair(?:ing)?\\b|подключ(?:ается|ение)\\b|соедин(?:яется|ение)\\b|正在连接|正在連接|配对中|配對中|连线中|連線中)"
+        },
+        {
+          "stage": 2,
+          "pattern": "(conectad[oa]s?\\b|paread[oa]s?\\b|emparelhad[oa]s?\\b|conex[aã]o\\s+estabelecida)"
+        },
+        {
+          "stage": 1,
+          "pattern": "(conectando\\b|pareando\\b|emparelhando\\b|tentando\\s+conectar|conex[aã]o\\s+em\\s+andamento)"
         }
       ]
     },
@@ -318,7 +476,10 @@
         "hiddify",
         "tailscale",
         "zerotier",
-        "shadowsocks"
+        "shadowsocks",
+        "tunel",
+        "túnel",
+        "proxy"
       ],
       "text_triggers": [
         "vpn",
@@ -339,12 +500,25 @@
         "已连线",
         "已連線",
         "已连接",
-        "已連接"
+        "已連接",
+        "túnel",
+        "tunel",
+        "conexão segura",
+        "conexao segura",
+        "conectado",
+        "conectada",
+        "proxy",
+        "nó",
+        "servidor"
       ],
       "signals": [
         {
           "stage": 1,
           "pattern": "(?<!\\d)\\d{1,4}(?:[.,]\\d{1,2})?\\s*(?:[kmgт]?i?[bб])\\s*(?:(?:/\\s*[sс])|(?:/\\s*sec)|ps)\\b|(已连接|已連接|已连线|已連線|connected|подключено)"
+        },
+        {
+          "stage": 1,
+          "pattern": "(?<!\\d)\\d{1,4}(?:[.,]\\d{1,2})?\\s*(?:[kmg]?i?[bB])\\s*(?:(?:/\\s*s)|(?:/\\s*seg)|ps)\\b|(vpn\\s+conectad[ao]|conectad[ao]\\s+[àa]\\s+vpn|t[úu]nel\\s+ativo|conex[aã]o\\s+segura\\s+ativa)"
         }
       ]
     }
@@ -367,7 +541,16 @@
     "內容已隱藏",
     "敏感內容已隱藏",
     "通知內容已隱藏",
-    "解鎖即可查看"
+    "解鎖即可查看",
+    "conteúdo oculto",
+    "conteudo oculto",
+    "conteúdo sensível oculto",
+    "conteudo sensivel oculto",
+    "conteúdo da notificação oculto",
+    "conteudo da notificacao oculto",
+    "desbloqueie para ver",
+    "desbloqueie para visualizar",
+    "oculto"
   ],
   "known_navigation_packages": [
     "ru.dublgis.dgismobile",
@@ -377,9 +560,17 @@
     "com.autonavi.minimap",
     "com.baidu.BaiduMap"
   ],
-  "navigation_package_markers": ["navigation", "navigator", ".maps", "navi"],
-  "navigation_distance_pattern": "(?<!\\d)\\d{1,4}(?:[\\s.,]\\d{1,2})?\\s*(?:км|km|м|m|mi|ft|миль|фут|公里|公尺|米)\\b",
-  "navigation_instruction_pattern": "(поверните[^\\n,.;:!]*|сверните[^\\n,.;:!]*|держитесь[^\\n,.;:!]*|развернитесь|turn\\s+(?:left|right)|keep\\s+(?:left|right)|take\\s+exit|u-?turn|roundabout|(?:向|往|朝)(?:东|南|西|北|前|后|左|右|東|後)(?:转|轉|方|行驶|行駛|走|直行)?|靠左行|靠右行|前方转弯|前方轉彎|进入环岛|進入圓環|驶出|駛出|步行|乘坐|等待)",
+  "navigation_package_markers": [
+    "navigation",
+    "navigator",
+    ".maps",
+    "navi",
+    "mapas",
+    "rotas",
+    "gps"
+  ],
+  "navigation_distance_pattern": "(?<!\\d)\\d{1,4}(?:[\\s.,]\\d{1,2})?\\s*(?:км|km|м|m|mi|ft|миль|фут|公里|公尺|米|metros?|quil[oô]metros?)\\b",
+  "navigation_instruction_pattern": "(поверните[^\\n,.;:!]*|сверните[^\\n,.;:!]*|держитесь[^\\n,.;:!]*|развернитесь|turn\\s+(?:left|right)|keep\\s+(?:left|right)|take\\s+exit|u-?turn|roundabout|(?:向|往|朝)(?:东|南|西|北|前|后|左|右|東|後)(?:转|轉|方|行驶|行駛|走|直行)?|靠左行|靠右行|前方转弯|前方轉彎|进入环岛|進入圓環|驶出|駛出|步行|乘坐|等待|vire\\s+(?:[àa]\\s+)?(?:esquerda|direita)|mantenha-se\\s+(?:[àa]\\s+)?(?:esquerda|direita)|pegue\\s+a\\s+sa[ií]da|fa[cç]a\\s+o\\s+retorno|entre\\s+na\\s+rotat[óo]ria|siga\\s+em\\s+frente|continue\\s+(?:em\\s+frente|reto)|radar\\s+[àa]\\s+frente)",
   "otp_strong_triggers": [
     "otp",
     "one-time password",
@@ -447,14 +638,37 @@
     "校验码",
     "校驗碼",
     "交易码",
-    "交易碼"
+    "交易碼",
+    "código",
+    "codigo",
+    "código de verificação",
+    "codigo de verificacao",
+    "código de confirmação",
+    "codigo de confirmacao",
+    "código de autenticação",
+    "codigo de autenticacao",
+    "código de autorização",
+    "codigo de autorizacao",
+    "código de segurança",
+    "codigo de seguranca",
+    "código de login",
+    "codigo de login",
+    "senha de uso único",
+    "senha de uso unico",
+    "senha temporária",
+    "senha temporaria",
+    "token",
+    "token de segurança",
+    "token de seguranca",
+    "verificação em duas etapas",
+    "verificacao em duas etapas"
   ],
-  "otp_loose_trigger_pattern": "(?:(?:\\bcode\\b|\\botp\\b|\\bpasscode\\b|\\bpassword\\b|kata\\s+sandi|\\bsandi\\b|\\bkode\\b|\\bкод\\b|验证码|驗證碼|密码|密碼|校验码|校驗碼)\\s*[:#-]?[\\s]*\\d(?:[\\s-]?\\d){3,7})",
-  "money_context_pattern": "(₽|руб\\.?|rub|usd|eur|kzt|тенге|р\\.|\\$|€|price|total|amount|sum|сумм|цена|стоимост|итого|￥|¥|twd|nt\\$|rmb|cny|hkd|金额|金額|总价|總價|合计|合計|消费|消費|付款|收款|扣款|转账|轉帳)",
+  "otp_loose_trigger_pattern": "(?:(?:\\bcode\\b|\\botp\\b|\\bpasscode\\b|\\bpassword\\b|kata\\s+sandi|\\bsandi\\b|\\bkode\\b|\\bкод\\b|验证码|驗證碼|密码|密碼|校验码|校驗碼)\\s*[:#-]?[\\s]*\\d(?:[\\s-]?\\d){3,7}|(?:(?:\\bc[óo]digo\\b|\\botp\\b|\\btoken\\b|\\bsenha\\b)\\s*(?:de\\s+(?:verifica[cç][aã]o|confirma[cç][aã]o|seguran[cç]a|login))?\\s*[:#-]?[\\s]*\\d(?:[\\s-]?\\d){3,7}))",
+  "money_context_pattern": "(₽|руб\\.?|rub|usd|eur|kzt|тенге|р\\.|\\$|€|price|total|amount|sum|сумм|цена|стоимост|итого|￥|¥|twd|nt\\$|rmb|cny|hkd|金额|金額|总价|總價|合计|合計|消费|消費|付款|收款|扣款|转账|轉帳|r\\$|brl|real|reais|pix|boleto|cart[aã]o|d[eé]bito|cr[eé]dito|pre[cç]o|valor|pagamento|pago|cobran[cç]a|transfer[êe]ncia|recebido|enviado)",
   "text_progress_percent_pattern": "(?<!\\d)(\\d{1,3})\\s*%",
   "text_progress_context_window": 80,
-  "text_progress_include_context_pattern": "(прогресс|выполн(?:ен|ено|яется|ение)|загруз(?:к|жается|жено)|скач(?:ив|ивает|ивание)|обновл(?:ен|ение|яется)|синхрон(?:изац|изируется)|обработ(?:к|ан|ает)|установ(?:к|лен)|remaining|progress|completed|completing|downloading|uploading|updating|installing|sync(?:ing)?|processing|processed|render(?:ing)?|encoding|decoding|进度|進度|完成|下载|下載|安装|安裝|更新|同步|处理|處理|加载|加載|备份|備份|解压缩|解壓縮|导出|匯出|导入|匯入)",
-  "text_progress_exclude_context_pattern": "(скид|акци|промокод|промо|купон|распрод|кэшб[еэ]к|кешб[еэ]к|discount|promo|coupon|sale|cashback|off\\b|выгод|bonus|бонус|save|deal|special\\s+offer|limited\\s+time|дарим|подар|при\\s+заказ|при\\s+покуп|minimum\\s+order|order\\s+from|в\\s+приложени\\S*\\s+акци|\\d{2,7}\\s*(?:₽|руб\\.?|рубл(?:ей|я|ь)?|rur|usd|eur|\\$|€|kzt|тенге)|влажност|humidity|погод|weather|температур|temperature|давлен|pressure|осадк|precip|комисси|commission|fee\\b|налог|tax\\b|apr\\b|\\bставк(?:а|и|у|е|ой|ах|ам|ами)?\\b|годов(?:ых|ая)?\\s*процент|процентн(?:ая|ые|ых)\\s+ставк|ипотек|кредит|депозит|вклад|сбор\\b|маркетплейс|посыл(?:к|ок)|почт[аы]|优惠|優惠|折扣|满减|滿減|红包|紅包|促销|促銷|免運|免运费|天气|天氣|温度|溫度|湿度|濕度|气压|氣壓|降水|利息|利率|电量|電量)",
+  "text_progress_include_context_pattern": "(прогресс|выполн(?:ен|ено|яется|ение)|загруз(?:к|жается|жено)|скач(?:ив|ивает|ивание)|обновл(?:ен|ение|яется)|синхрон(?:изац|изируется)|обработ(?:к|ан|ает)|установ(?:к|лен)|remaining|progress|completed|completing|downloading|uploading|updating|installing|sync(?:ing)?|processing|processed|render(?:ing)?|encoding|decoding|进度|進度|完成|下载|下載|安装|安裝|更新|同步|处理|處理|加载|加載|备份|備份|解压缩|解壓縮|导出|匯出|导入|匯入|progresso|conclu[ií]d[oa]|baixando|enviando|atualizando|instalando|sincronizando|processando|renderizando|codificando|decodificando|carregando|backup|extraindo|exportando|importando)",
+  "text_progress_exclude_context_pattern": "(скид|акци|промокод|промо|купон|распрод|кэшб[еэ]к|кешб[еэ]к|discount|promo|coupon|sale|cashback|off\\b|выгод|bonus|бонус|save|deal|special\\s+offer|limited\\s+time|дарим|подар|при\\s+заказ|при\\s+покуп|minimum\\s+order|order\\s+from|в\\s+приложени\\S*\\s+акци|\\d{2,7}\\s*(?:₽|руб\\.?|рубл(?:ей|я|ь)?|rur|usd|eur|\\$|€|kzt|тенге)|влажност|humidity|погод|weather|температур|temperature|давлен|pressure|осадк|precip|комисси|commission|fee\\b|налог|tax\\b|apr\\b|\\bставк(?:а|и|у|е|ой|ах|ам|ами)?\\b|годов(?:ых|ая)?\\s*процент|процентн(?:ая|ые|ых)\\s+ставк|ипотек|кредит|депозит|вклад|сбор\\b|маркетплейс|посыл(?:к|ок)|почт[аы]|优惠|優惠|折扣|满减|滿減|红包|紅包|促销|促銷|免運|免运费|天气|天氣|温度|溫度|湿度|濕度|气压|氣壓|降水|利息|利率|电量|電量|desconto|promo[cç][aã]o|cupom|oferta|frete\\s+gr[áa]tis|economize|b[oô]nus|\\d{1,7}\\s*(?:r\\$|reais?|brl)|umidade|clima|temperatura|press[aã]o|chuva|taxa|juros|imposto|parcelamento|cr[eé]dito|boleto|pix|encomenda|correios)",
   "weather_package_hints": [
     "weather",
     "sec.android.daemonapp",
@@ -466,23 +680,32 @@
     "pogoda",
     "clime",
     "1weather",
-    "todayweather"
+    "todayweather",
+    "clima",
+    "tempo",
+    "previsao",
+    "previsão",
+    "cptec",
+    "inmet",
+    "climatempo"
   ],
-  "weather_context_pattern": "(погод|weather|температур|temperature|ощущаетс|feels like|влажност|humidity|ветер|wind|осадк|precip|давлен|pressure|прогноз|forecast|uv|aqi|today|tomorrow|highs?|lows?|sunny|clear|cloudy|overcast|rain(?:y)?|snow(?:y)?|fog(?:gy)?|mist|haze|wind(?:y)?|gust(?:y)?|thunder(?:storm)?|storm(?:y)?|天气|天氣|温度|溫度|体感|體感|湿度|濕度|风|風|降水|气压|氣壓|预报|預報|晴天|雨天|多云|多雲|雷阵雨|雷陣雨|台风|颱風|暴雨|豪雨|雷暴|雨)",
-  "weather_temperature_pattern": "(?<!\\d)([+\\-−]?\\d{1,3})\\s*(?:°(?:\\s*(?:c|f|с|ф)(?!\\p{L}))?|℃|℉)",
-  "weather_day_pattern": "(сегодня|завтра|утром|днем|вечером|ночью|today|tomorrow|morning|afternoon|evening|night|今天|明天|早上|上午|下午|晚上|夜间|夜間)",
-  "weather_condition_pattern": "(ясно|пасмурно|облачно|дожд|снег|туман|ветрено|солнечно|sunny|cloudy|overcast|rain|snow|fog|windy|clear|晴|阴|陰|多云|多雲|阵雨|陣雨|雷阵雨|雷陣雨|暴雨|台风|颱風|下雪|大雪|雾|霧|晴天|雨天|多云|多雲|雷阵雨|雷陣雨|台风|颱風|暴雨|豪雨|雷暴|雨)",
-  "weather_condition_thunder_pattern": "(гроз|thunder|storm|雷|风暴|風暴)",
-  "weather_condition_rain_pattern": "(дожд|rain|shower|雨|降水)",
-  "weather_condition_snow_pattern": "(снег|snow|sleet|blizzard|雪|冰雹)",
-  "weather_condition_fog_pattern": "(туман|mist|fog|haze|雾|霧|霾)",
-  "weather_condition_wind_pattern": "(ветер|ветрено|wind|windy|gust|风|風)",
-  "weather_condition_sun_pattern": "(солнечно|ясно|sunny|clear|晴|阳光|陽光)",
-  "weather_condition_cloud_pattern": "(пасмурно|облачно|cloud|overcast|阴|陰|云|雲)",
+  "weather_context_pattern": "(погод|weather|температур|temperature|ощущаетс|feels like|влажност|humidity|ветер|wind|осадк|precip|давлен|pressure|прогноз|forecast|uv|aqi|today|tomorrow|highs?|lows?|sunny|clear|cloudy|overcast|rain(?:y)?|snow(?:y)?|fog(?:gy)?|mist|haze|wind(?:y)?|gust(?:y)?|thunder(?:storm)?|storm(?:y)?|天气|天氣|温度|溫度|体感|體感|湿度|濕度|风|風|降水|气压|氣壓|预报|預報|晴天|雨天|多云|多雲|雷阵雨|雷陣雨|台风|颱風|暴雨|豪雨|雷暴|雨|clima|tempo|temperatura|sensa[cç][aã]o\\s+t[ée]rmica|umidade|vento|chuva|precipita[cç][aã]o|press[aã]o|previs[aã]o|qualidade\\s+do\\s+ar|hoje|amanh[aã]|ensolarado|nublado|chuvoso|tempestade|trovoada|neblina|garoa)",
+  "weather_temperature_pattern": "(?<!\\d)([+\\-−]?\\d{1,3})\\s*(?:°(?:\\s*(?:c|f|с|ф)(?!\\p{L}))?|℃|℉|º\\s*(?:c|f)?|graus)",
+  "weather_day_pattern": "(сегодня|завтра|утром|днем|вечером|ночью|today|tomorrow|morning|afternoon|evening|night|今天|明天|早上|上午|下午|晚上|夜间|夜間|hoje|amanh[aã]|manh[aã]|tarde|noite|madrugada)",
+  "weather_condition_pattern": "(ясно|пасмурно|облачно|дожд|снег|туман|ветрено|солнечно|sunny|cloudy|overcast|rain|snow|fog|windy|clear|晴|阴|陰|多云|多雲|阵雨|陣雨|雷阵雨|雷陣雨|暴雨|台风|颱風|下雪|大雪|雾|霧|晴天|雨天|多云|多雲|雷阵雨|雷陣雨|台风|颱風|暴雨|豪雨|雷暴|雨|ensolarado|sol|claro|nublado|encoberto|chuva|chuvoso|garoa|temporal|tempestade|trovoada|neblina|vento|ventania)",
+  "weather_condition_thunder_pattern": "(гроз|thunder|storm|雷|风暴|風暴|trov[aã]o|trovoada|tempestade|temporal|raio)",
+  "weather_condition_rain_pattern": "(дожд|rain|shower|雨|降水|chuva|chuvoso|garoa|precipita[cç][aã]o)",
+  "weather_condition_snow_pattern": "(снег|snow|sleet|blizzard|雪|冰雹|neve|granizo)",
+  "weather_condition_fog_pattern": "(туман|mist|fog|haze|雾|霧|霾|neblina|nevoeiro|cerra[cç][aã]o)",
+  "weather_condition_wind_pattern": "(ветер|ветрено|wind|windy|gust|风|風|vento|ventania|ventoso|rajada)",
+  "weather_condition_sun_pattern": "(солнечно|ясно|sunny|clear|晴|阳光|陽光|sol|ensolarado|claro|tempo\\s+aberto)",
+  "weather_condition_cloud_pattern": "(пасмурно|облачно|cloud|overcast|阴|陰|云|雲|nublado|encoberto|nebulosidade|nuvem|nuvens)",
   "external_device_name_patterns": [
     "(?:connected|connecting|pair(?:ed|ing)|подключ(?:ен(?:а|о|ы)?|ается|ение)|соедин(?:ен(?:а|о|ы)?|яется))\\s*(?:to|к)?\\s*[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?(?=\\s|$|[,.!])",
     "[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?\\s*(?:is\\s+)?(?:connected|connecting|pair(?:ed|ing)|подключ(?:ен(?:а|о|ы)?|ается|ение)|соедин(?:ен(?:а|о|ы)?|яется))\\b",
-    "[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?\\s*(?:已连接|已連接|配对成功|配對成功|已连线|已連線|正在连接|正在連接)"
+    "[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?\\s*(?:已连接|已連接|配对成功|配對成功|已连线|已連線|正在连接|正在連接)",
+    "(?:conectad[oa]s?|conectando|paread[oa]s?|pareando|emparelhad[oa]s?|emparelhando)\\s*(?:a|ao|à|com)?\\s*[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?(?=\\s|$|[,.!])",
+    "[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?\\s*(?:est[aá]\\s+)?(?:conectad[oa]s?|conectando|paread[oa]s?|pareando|emparelhad[oa]s?|emparelhando)\\b"
   ],
   "external_device_generic_names": [
     "device",
@@ -520,10 +743,25 @@
     "手表",
     "手錶",
     "手环",
-    "手環"
+    "手環",
+    "dispositivo",
+    "dispositivos",
+    "1 dispositivo",
+    "2 dispositivos",
+    "3 dispositivos",
+    "câmera",
+    "acessório",
+    "acessorio",
+    "ponto de acesso",
+    "fone",
+    "fone de ouvido",
+    "relógio",
+    "relogio",
+    "smartwatch",
+    "pulseira"
   ],
-  "vpn_speed_pattern": "(?<!\\d)\\d{1,4}(?:[.,]\\d{1,2})?\\s*(?:[kmgт]?i?[bб])\\s*(?:(?:/\\s*[sс])|(?:/\\s*sec)|ps)\\b",
-  "vpn_context_pattern": "(\\bvpn\\b|wireguard|openvpn|hiddify|clash|v2ray|singbox|outline|amnezia|tailscale|zerotier|туннел|прокси|proxy|代理|节点|節點)",
+  "vpn_speed_pattern": "(?<!\\d)\\d{1,4}(?:[.,]\\d{1,2})?\\s*(?:[kmgт]?i?[bб])\\s*(?:(?:/\\s*[sс])|(?:/\\s*sec)|ps)\\b|(?<!\\d)\\d{1,4}(?:[.,]\\d{1,2})?\\s*(?:[kmg]?i?[bB])\\s*(?:(?:/\\s*s)|(?:/\\s*seg)|ps)\\b",
+  "vpn_context_pattern": "(\\bvpn\\b|wireguard|openvpn|hiddify|clash|v2ray|singbox|outline|amnezia|tailscale|zerotier|туннел|прокси|proxy|代理|节点|節點|t[úu]nel|conex[aã]o\\s+segura|servidor|n[óo])",
   "vpn_package_markers": [
     "hiddify",
     "wireguard",
@@ -541,7 +779,10 @@
     "tailscale",
     "zerotier",
     "shadowsocks",
-    "vpn"
+    "vpn",
+    "tunnel",
+    "tunel",
+    "proxy"
   ],
   "vpn_download_markers": [
     "↓",
@@ -560,7 +801,13 @@
     "приём",
     "下载",
     "下載",
-    "接收"
+    "接收",
+    "baixar",
+    "baixando",
+    "receber",
+    "recebido",
+    "entrada",
+    "entrante"
   ],
   "vpn_upload_markers": [
     "↑",
@@ -578,13 +825,18 @@
     "上传",
     "上傳",
     "发送",
-    "發送"
+    "發送",
+    "enviar",
+    "enviando",
+    "saída",
+    "saida"
   ],
   "otp_code_patterns": [
     "(?:\\bcode\\b|\\botp\\b|\\bpasscode\\b|\\bpassword\\b|kata\\s+sandi|\\bsandi\\b|\\bkode\\b|\\bкод\\b|пароль|验证码|驗證碼|密码|密碼|校验码|校驗碼)[^\\d\\n]{0,80}(\\d(?:[\\s-]?\\d){3,7})(?!\\d)",
     "(?<!\\S)(\\d{4,8})(?!\\d)",
     "(?<!\\S)(\\d(?:[\\s-]?\\d){3,7})(?!\\d)",
-    "(?<!\\S)([A-Z0-9]{4,8})(?!\\w)"
+    "(?<!\\S)([A-Z0-9]{4,8})(?!\\w)",
+    "(?:\\bc[óo]digo\\b|\\botp\\b|\\btoken\\b|\\bsenha\\b)[^\\d\\n]{0,80}(\\d(?:[\\s-]?\\d){3,7})(?!\\d)"
   ],
   "order_context_hints": [
     "заказ",
@@ -593,12 +845,17 @@
     "достав",
     "订单",
     "訂單",
-    "配送"
+    "配送",
+    "pedido",
+    "entrega",
+    "rastreamento"
   ],
   "entity_token_patterns": [
     "(?:заказ|order|trip|ride|поездк[аы]|订单|訂單|行程)\\s*(?:#|№|id|no\\.?|number|номер|编号|編號|号|號)\\s*([a-zA-Z0-9-]{2,16})",
     "(?:заказ|order|trip|ride|поездк[аы]|订单|訂單|行程)\\s+([a-zA-Z0-9-]*\\d[a-zA-Z0-9-]{1,15})",
-    "(?:#|№)\\s*([a-zA-Z0-9-]{2,16})"
+    "(?:#|№)\\s*([a-zA-Z0-9-]{2,16})",
+    "(?:pedido|corrida|viagem|entrega)\\s*(?:#|n[ºo°]|id|n[uú]mero|c[óo]digo)\\s*([a-zA-Z0-9-]{2,16})",
+    "(?:pedido|corrida|viagem|entrega)\\s+([a-zA-Z0-9-]*\\d[a-zA-Z0-9-]{1,15})"
   ],
   "status_labels": {
     "food": {
@@ -629,6 +886,13 @@
         "2": "待取餐",
         "3": "外送中",
         "4": "已送達"
+      },
+      "pt-BR": {
+        "0": "Pago",
+        "1": "Preparando",
+        "2": "Pronto",
+        "3": "A caminho",
+        "4": "Entregue"
       }
     },
     "taxi": {
@@ -659,6 +923,13 @@
         "2": "即將抵達",
         "3": "行程中",
         "4": "已到達"
+      },
+      "pt-BR": {
+        "0": "Buscando",
+        "1": "Motorista",
+        "2": "Chegando",
+        "3": "Em viagem",
+        "4": "Concluída"
       }
     },
     "navigation": {
@@ -685,6 +956,12 @@
         "2": "導航中",
         "3": "即將到達",
         "4": "已到達"
+      },
+      "pt-BR": {
+        "1": "Rota",
+        "2": "Navegação",
+        "3": "Quase lá",
+        "4": "Chegou"
       }
     },
     "external_device": {
@@ -703,6 +980,10 @@
       "zh-TW": {
         "1": "連接中",
         "2": "已連接"
+      },
+      "pt-BR": {
+        "1": "Conectando",
+        "2": "Conectado"
       }
     },
     "vpn": {
@@ -716,6 +997,9 @@
         "1": "VPN"
       },
       "zh-TW": {
+        "1": "VPN"
+      },
+      "pt-BR": {
         "1": "VPN"
       }
     }

--- a/android/app/src/main/assets/liveupdate_dictionary_pt-BR.json
+++ b/android/app/src/main/assets/liveupdate_dictionary_pt-BR.json
@@ -1,0 +1,584 @@
+{
+  "smart_rules": [
+    {
+      "id": "food",
+      "max_stage": 4,
+      "package_hints": [
+        "ifood",
+        "rappi",
+        "ubereats",
+        "uber.eats",
+        "99food",
+        "aiqfome",
+        "aiq",
+        "delivery",
+        "deliverymuch",
+        "delivery.much",
+        "ze.delivery",
+        "zedelivery",
+        "zé delivery",
+        "kfc",
+        "mcdonalds",
+        "mcdonald",
+        "burgerking",
+        "burger.king",
+        "bk",
+        "subway",
+        "dominos",
+        "domino",
+        "habibs",
+        "giraffas",
+        "outback",
+        "pizza",
+        "food",
+        "eats"
+      ],
+      "text_triggers": [
+        "pedido",
+        "entrega",
+        "delivery",
+        "comida",
+        "lanche",
+        "restaurante",
+        "mercado",
+        "refeição",
+        "motoboy",
+        "entregador",
+        "entregadora",
+        "retirada",
+        "retirar",
+        "cozinha",
+        "preparo",
+        "pedido confirmado",
+        "pedido aceito",
+        "saiu para entrega",
+        "a caminho"
+      ],
+      "exclude_patterns": [
+        "(anivers[aá]rio|feliz anivers[aá]rio|birthday)",
+        "(desconto|cupom|promo[cç][aã]o|promocional|oferta|cashback|cash\\s*back|c[oó]digo\\s+promocional|voucher|brinde|ganhe\\s+\\d+%|\\d+%\\s*(?:off|de\\s+desconto)|frete\\s+gr[aá]tis|entrega\\s+gr[aá]tis)",
+        "(pagamento\\s*(?:falhou|recusado|negado|n[aã]o\\s+aprovado|n[aã]o\\s+autorizado|pendente)|compra\\s+cancelada|pedido\\s+cancelado|cancelamos\\s+seu\\s+pedido|estorno|reembolso|valor\\s+estornado)",
+        "(carrinho|sacola|checkout|finalize\\s+(?:sua\\s+)?compra|complete\\s+(?:seu\\s+)?pedido|concluir\\s+pedido|fechar\\s+pedido|retomar\\s+pedido)",
+        "(pedido\\s+m[ií]nimo|compra\\s+m[ií]nima|nas\\s+compras\\s+acima\\s+de|compre\\s+e\\s+ganhe)",
+        "(correios|transportadora|rastreio|rastreamento|c[oó]digo\\s+de\\s+rastreio|objeto\\s+postado|objeto\\s+saiu|sua\\s+encomenda|sua\\s+compra\\s+chegou|pacote|retire\\s+sua\\s+encomenda|locker|ponto\\s+de\\s+retirada|marketplace|mercado\\s+livre|amazon|shopee|shein|magalu|americanas)"
+      ],
+      "signals": [
+        {
+          "stage": 4,
+          "pattern": "(pedido\\s*(?:entregue|finalizado|conclu[ií]do)|entrega\\s*(?:realizada|conclu[ií]da|finalizada)|seu\\s+pedido\\s+chegou|j[aá]\\s+entregamos|foi\\s+entregue|bom\\s+apetite|aproveite\\s+(?:sua\\s+)?refei[cç][aã]o|obrigado\\s+por\\s+pedir)"
+        },
+        {
+          "stage": 3,
+          "pattern": "(pedido[^\\n]{0,60}(?:saiu\\s+para\\s+entrega|est[aá]\\s+a\\s+caminho|a\\s+caminho|em\\s+rota|em\\s+deslocamento|chegando)|entrega[^\\n]{0,60}(?:a\\s+caminho|em\\s+rota|chegando)|(?:entregador|entregadora|motoboy|motofretista|rider)[^\\n]{0,80}(?:saiu|retirou|pegou|coletou|est[aá]\\s+a\\s+caminho|a\\s+caminho|em\\s+rota|chegando|pr[oó]ximo|pr[oó]xima)|sua\\s+comida\\s+est[aá]\\s+a\\s+caminho|estamos\\s+levando\\s+seu\\s+pedido|acompanhe\\s+a\\s+entrega)"
+        },
+        {
+          "stage": 2,
+          "pattern": "(pedido[^\\n]{0,60}(?:pronto|preparado|separado|embalado|aguardando\\s+(?:retirada|entregador)|liberado\\s+para\\s+retirada|pronto\\s+para\\s+retirada)|pronto\\s+para\\s+retirada|retire\\s+(?:seu\\s+)?pedido|j[aá]\\s+pode\\s+retirar|(?:entregador|entregadora|motoboy)[^\\n]{0,60}(?:aceitou|foi\\s+definido|foi\\s+designado))"
+        },
+        {
+          "stage": 1,
+          "pattern": "(pedido[^\\n]{0,60}(?:em\\s+preparo|est[aá]\\s+sendo\\s+preparado|come[cç]ou\\s+a\\s+ser\\s+preparado|est[aá]\\s+na\\s+cozinha|preparando|em\\s+produ[cç][aã]o)|restaurante[^\\n]{0,60}(?:aceitou|confirmou|recebeu|est[aá]\\s+preparando)|cozinha[^\\n]{0,60}(?:iniciou|come[cç]ou)|estamos\\s+preparando\\s+seu\\s+pedido)"
+        },
+        {
+          "stage": 0,
+          "pattern": "(pedido[^\\n]{0,60}(?:recebido|realizado|feito|criado|confirmado|aceito|aprovado|registrado|pago)|pagamento[^\\n]{0,60}(?:aprovado|confirmado|recebido|realizado)|recebemos\\s+seu\\s+pedido|confirmamos\\s+seu\\s+pedido|seu\\s+pedido\\s+foi\\s+aceito)"
+        }
+      ]
+    },
+    {
+      "id": "taxi",
+      "max_stage": 4,
+      "package_hints": [
+        "uber",
+        "99",
+        "99app",
+        "cabify",
+        "indrive",
+        "in.driver",
+        "taxi",
+        "táxi",
+        "mobizap",
+        "yango",
+        "didi",
+        "lyft",
+        "bolt",
+        "grab"
+      ],
+      "text_triggers": [
+        "corrida",
+        "viagem",
+        "táxi",
+        "taxi",
+        "motorista",
+        "carro",
+        "veículo",
+        "placa",
+        "embarque",
+        "desembarque",
+        "partida",
+        "destino",
+        "passageiro",
+        "app de corrida"
+      ],
+      "signals": [
+        {
+          "stage": 4,
+          "pattern": "(corrida\\s+(?:finalizada|conclu[ií]da|encerrada)|viagem\\s+(?:finalizada|conclu[ií]da|encerrada)|voc[eê]\\s+chegou\\s+ao\\s+destino|chegamos\\s+ao\\s+destino|destino\\s+alcan[cç]ado|pagamento\\s+da\\s+corrida|avalie\\s+(?:sua\\s+)?(?:corrida|viagem|motorista))"
+        },
+        {
+          "stage": 3,
+          "pattern": "(corrida\\s+(?:iniciada|come[cç]ou|em\\s+andamento)|viagem\\s+(?:iniciada|come[cç]ou|em\\s+andamento)|voc[eê]\\s+est[aá]\\s+em\\s+viagem|embarque\\s+confirmado|aproveite\\s+(?:sua\\s+)?viagem|siga\\s+viagem|a\\s+caminho\\s+do\\s+destino)"
+        },
+        {
+          "stage": 2,
+          "pattern": "(motorista[^\\n]{0,80}(?:est[aá]\\s+chegando|chega\\s+em|a\\s+caminho|est[aá]\\s+pr[oó]ximo|est[aá]\\s+perto|chegou|j[aá]\\s+chegou)|carro[^\\n]{0,80}(?:est[aá]\\s+chegando|a\\s+caminho|chegou)|chegando\\s+em\\s*\\d+\\s*(?:min|minutos?)|v[aá]\\s+at[eé]\\s+o\\s+local\\s+de\\s+embarque|dirija-se\\s+ao\\s+embarque)"
+        },
+        {
+          "stage": 1,
+          "pattern": "(motorista[^\\n]{0,80}(?:encontrado|definido|designado|aceitou|confirmou|foi\\s+encontrado|foi\\s+chamado)|corrida[^\\n]{0,80}(?:aceita|confirmada)|viagem[^\\n]{0,80}(?:aceita|confirmada)|encontramos\\s+um\\s+motorista|seu\\s+motorista\\s+ser[aá])"
+        },
+        {
+          "stage": 0,
+          "pattern": "(procurando\\s+(?:um\\s+)?motorista|buscando\\s+(?:um\\s+)?motorista|chamando\\s+(?:um\\s+)?motorista|solicitando\\s+(?:sua\\s+)?corrida|pedido\\s+de\\s+corrida\\s+enviado|aguardando\\s+(?:motorista|aceite)|encontrando\\s+(?:um\\s+)?motorista)"
+        }
+      ]
+    },
+    {
+      "id": "navigation",
+      "max_stage": 4,
+      "package_hints": [
+        "google.android.apps.maps",
+        "waze",
+        "maps",
+        "map",
+        "navigator",
+        "navigation",
+        "navegacao",
+        "navegação",
+        "navi",
+        "here",
+        "tomtom",
+        "moovit",
+        "citymapper",
+        "amap",
+        "baidu.BaiduMap"
+      ],
+      "text_triggers": [
+        "rota",
+        "trajeto",
+        "navegação",
+        "navegacao",
+        "destino",
+        "vire à esquerda",
+        "vire a esquerda",
+        "vire à direita",
+        "vire a direita",
+        "mantenha à esquerda",
+        "mantenha a esquerda",
+        "mantenha à direita",
+        "mantenha a direita",
+        "siga em frente",
+        "continue",
+        "pegue a saída",
+        "saída",
+        "rotatória",
+        "retorno",
+        "faça o retorno",
+        "radar",
+        "trânsito"
+      ],
+      "exclude_patterns": [
+        "(anivers[aá]rio|feliz anivers[aá]rio|birthday)",
+        "(desconto|cupom|promo[cç][aã]o|oferta|cashback|\\d+%\\s*(?:off|de\\s+desconto)|frete\\s+gr[aá]tis)",
+        "(newsletter|boletim|siga-nos|baixar\\s+app|download\\s+do\\s+app|atualiza[cç][aã]o\\s+do\\s+mapa)"
+      ],
+      "signals": [
+        {
+          "stage": 4,
+          "pattern": "(voc[eê]\\s+chegou|chegou\\s+ao\\s+destino|destino\\s+alcan[cç]ado|rota\\s+(?:finalizada|conclu[ií]da|encerrada)|navega[cç][aã]o\\s+(?:finalizada|encerrada)|fim\\s+da\\s+rota)"
+        },
+        {
+          "stage": 3,
+          "pattern": "(destino[^\\n]{0,80}(?:à\\s+direita|a\\s+direita|à\\s+esquerda|a\\s+esquerda|logo\\s+à\\s+frente|logo\\s+a\\s+frente|pr[oó]ximo|pr[oó]xima)|voc[eê]\\s+est[aá]\\s+quase\\s+l[aá]|faltam\\s*\\d+\\s*(?:m|metros?|km|quil[oô]metros?)|aproximando-se\\s+do\\s+destino|quase\\s+no\\s+destino)"
+        },
+        {
+          "stage": 2,
+          "pattern": "(em\\s*\\d+[\\d\\s.,]*\\s*(?:m|metros?|km|quil[oô]metros?)|\\b\\d+[\\d\\s.,]*\\s*(?:m|metros?|km|quil[oô]metros?)\\b|vire\\s+(?:à|a)\\s+(?:esquerda|direita)|mantenha-se?\\s+(?:à|a)\\s+(?:esquerda|direita)|pegue\\s+a\\s+sa[ií]da|entre\\s+na\\s+rotat[oó]ria|saia\\s+da\\s+rotat[oó]ria|fa[cç]a\\s+o\\s+retorno|continue\\s+(?:em\\s+frente|reto|na\\s+via)|siga\\s+(?:em\\s+frente|reto|pela)|acesse\\s+a\\s+via|use\\s+a\\s+faixa|radar\\s+à\\s+frente|tr[aâ]nsito\\s+à\\s+frente)"
+        },
+        {
+          "stage": 1,
+          "pattern": "(rota\\s+(?:iniciada|calculada|tra[cç]ada|definida)|navega[cç][aã]o\\s+(?:iniciada|come[cç]ou)|iniciando\\s+(?:a\\s+)?rota|siga\\s+a\\s+rota|come[cç]ar\\s+navega[cç][aã]o)"
+        }
+      ]
+    },
+    {
+      "id": "external_device",
+      "max_stage": 2,
+      "package_hints": [
+        "camera",
+        "bluetooth",
+        "accessory",
+        "usb",
+        "gopro",
+        "dji",
+        "wearable",
+        "galaxywearable",
+        "miui",
+        "samsung",
+        "garmin",
+        "huaweihealth",
+        "fitbit",
+        "amazfit",
+        "zepp"
+      ],
+      "text_triggers": [
+        "câmera",
+        "camera",
+        "bluetooth",
+        "acessório",
+        "acessorio",
+        "usb",
+        "fone",
+        "fone de ouvido",
+        "relógio",
+        "relogio",
+        "smartwatch",
+        "pulseira",
+        "wearable",
+        "emparelhado",
+        "pareado",
+        "conectado",
+        "conectando",
+        "desconectado",
+        "dispositivo"
+      ],
+      "exclude_patterns": [
+        "(anivers[aá]rio|feliz anivers[aá]rio|birthday)",
+        "(desconto|cupom|promo[cç][aã]o|oferta|cashback|\\d+%\\s*(?:off|de\\s+desconto))",
+        "(roteador|ponto\\s+de\\s+acesso|hotspot|tethering|compartilhamento\\s+de\\s+internet|wi-?fi|wifi|rede\\s+wi-?fi|\\b\\d+\\s+dispositivos?\\s+conectados?)"
+      ],
+      "signals": [
+        {
+          "stage": 2,
+          "pattern": "(conectad[oa]s?\\b|emparelhad[oa]s?\\b|paread[oa]s?\\b|conex[aã]o\\s+estabelecida|emparelhamento\\s+conclu[ií]do|pareamento\\s+conclu[ií]do|dispositivo\\s+conectado|fone\\s+conectado|rel[oó]gio\\s+conectado)"
+        },
+        {
+          "stage": 1,
+          "pattern": "(conectando\\b|emparelhando\\b|pareando\\b|conex[aã]o\\s+em\\s+andamento|tentando\\s+conectar|procurando\\s+dispositivo|buscando\\s+dispositivo)"
+        }
+      ]
+    },
+    {
+      "id": "vpn",
+      "max_stage": 1,
+      "package_hints": [
+        "vpn",
+        "wireguard",
+        "openvpn",
+        "nordvpn",
+        "protonvpn",
+        "surfshark",
+        "expressvpn",
+        "outline",
+        "amnezia",
+        "clash",
+        "v2ray",
+        "hiddify",
+        "tailscale",
+        "zerotier",
+        "shadowsocks",
+        "singbox",
+        "hysteria"
+      ],
+      "text_triggers": [
+        "vpn",
+        "wireguard",
+        "openvpn",
+        "túnel",
+        "tunel",
+        "conexão segura",
+        "conexao segura",
+        "conexão protegida",
+        "conexao protegida",
+        "proxy",
+        "procurador",
+        "nó",
+        "servidor vpn",
+        "conectado",
+        "conectada"
+      ],
+      "signals": [
+        {
+          "stage": 1,
+          "pattern": "(?<!\\d)\\d{1,4}(?:[.,]\\d{1,2})?\\s*(?:[kmg]?i?b|[kmg]?b|kb|mb|gb)\\s*(?:(?:/\\s*s)|(?:/\\s*seg)|(?:/\\s*sec)|ps)\\b|(?:vpn|t[uú]nel|proxy)[^\\n]{0,60}(?:conectad[oa]|ativo|protegido|seguro)|conex[aã]o\\s+(?:segura|protegida|estabelecida|ativa)"
+        }
+      ]
+    }
+  ],
+  "blocked_source_packages": [],
+  "privacy_redaction_placeholders": [
+    "conteúdo sensível oculto",
+    "conteúdo oculto",
+    "conteudo sensivel oculto",
+    "conteudo oculto",
+    "notificação com conteúdo oculto",
+    "notificacao com conteudo oculto",
+    "notificação oculta",
+    "notificacao oculta",
+    "desbloqueie para ver",
+    "desbloqueie para visualizar",
+    "desbloqueie o dispositivo para ver",
+    "oculto por segurança",
+    "mensagem oculta",
+    "prévia oculta",
+    "previa oculta"
+  ],
+  "known_navigation_packages": [
+    "com.google.android.apps.maps",
+    "com.waze",
+    "com.here.app.maps",
+    "com.tomtom.gplay.navapp",
+    "com.citymapper.app.release",
+    "com.tranzmate",
+    "ru.dublgis.dgismobile",
+    "ru.yandex.yandexmaps",
+    "com.autonavi.minimap",
+    "com.baidu.BaiduMap"
+  ],
+  "navigation_package_markers": [
+    "navigation",
+    "navigator",
+    ".maps",
+    "maps",
+    "map",
+    "navi",
+    "waze",
+    "moovit",
+    "rotas",
+    "navegacao",
+    "navegação"
+  ],
+  "navigation_distance_pattern": "(?<!\\d)\\d{1,4}(?:[\\s.,]\\d{1,2})?\\s*(?:km|quil[oô]metros?|m|metros?)\\b",
+  "navigation_instruction_pattern": "(vire\\s+(?:à|a)\\s+(?:esquerda|direita)|mantenha-se?\\s+(?:à|a)\\s+(?:esquerda|direita)|pegue\\s+a\\s+sa[ií]da|entre\\s+na\\s+rotat[oó]ria|saia\\s+da\\s+rotat[oó]ria|fa[cç]a\\s+o\\s+retorno|siga\\s+(?:em\\s+frente|reto|pela)|continue\\s+(?:em\\s+frente|reto)|acesse\\s+a\\s+via|use\\s+a\\s+faixa|radar\\s+à\\s+frente|tr[aâ]nsito\\s+à\\s+frente)",
+  "otp_strong_triggers": [
+    "otp",
+    "código de verificação",
+    "codigo de verificacao",
+    "código verificador",
+    "codigo verificador",
+    "código de confirmação",
+    "codigo de confirmacao",
+    "código de autenticação",
+    "codigo de autenticacao",
+    "código de autorização",
+    "codigo de autorizacao",
+    "código de segurança",
+    "codigo de seguranca",
+    "código de acesso",
+    "codigo de acesso",
+    "código de login",
+    "codigo de login",
+    "código para entrar",
+    "codigo para entrar",
+    "senha temporária",
+    "senha temporaria",
+    "senha de uso único",
+    "senha de uso unico",
+    "token de segurança",
+    "token de seguranca",
+    "token",
+    "2fa",
+    "dois fatores",
+    "duplo fator",
+    "validação",
+    "validacao",
+    "verificação",
+    "verificacao",
+    "confirmação",
+    "confirmacao",
+    "autenticação",
+    "autenticacao",
+    "pix copia e cola",
+    "código pix",
+    "codigo pix"
+  ],
+  "otp_loose_trigger_pattern": "(?:(?:\\bc[oó]digo\\b|\\botp\\b|\\btoken\\b|\\bsenha\\b|verifica[cç][aã]o|confirma[cç][aã]o|autentica[cç][aã]o|autoriza[cç][aã]o)\\s*[:#-]?\\s*\\d(?:[\\s-]?\\d){3,7})",
+  "money_context_pattern": "(R\\$|BRL|real|reais|pix|boleto|cart[aã]o|cr[eé]dito|d[eé]bito|pre[cç]o|valor|total|subtotal|pagamento|pago|compra|cobran[cç]a|cobrado|d[eé]bito|transfer[eê]ncia|saldo|fatura|parcela|taxa|frete|reembolso|estorno)",
+  "text_progress_percent_pattern": "(?<!\\d)(\\d{1,3})\\s*%",
+  "text_progress_context_window": 80,
+  "text_progress_include_context_pattern": "(progresso|conclu[ií]d[oa]|concluir|baixando|download|enviando|upload|subindo|atualizando|instalando|sincronizando|sync|processando|processado|renderizando|codificando|decodificando|carregando|importando|exportando|backup|restaurando|extraindo|compactando|descompactando|preparando|faltam|restante)",
+  "text_progress_exclude_context_pattern": "(desconto|cupom|promo[cç][aã]o|oferta|cashback|cash\\s*back|off\\b|economize|ganhe|brinde|b[oô]nus|frete\\s+gr[aá]tis|entrega\\s+gr[aá]tis|pedido\\s+m[ií]nimo|compra\\s+m[ií]nima|\\d{1,7}\\s*(?:R\\$|reais|BRL)|umidade|clima|tempo|temperatura|press[aã]o|chuva|vento|previs[aã]o|comiss[aã]o|taxa|juros|imposto|financiamento|empr[eé]stimo|cart[aã]o|fatura|bateria|carga)",
+  "weather_package_hints": [
+    "weather",
+    "clima",
+    "tempo",
+    "previsao",
+    "previsão",
+    "climatempo",
+    "br.com.climatempo",
+    "sec.android.daemonapp",
+    "meteo",
+    "accuweather",
+    "weatherchannel",
+    "gismeteo",
+    "yandex.weather",
+    "clime",
+    "1weather",
+    "todayweather"
+  ],
+  "weather_context_pattern": "(clima|tempo|previs[aã]o|temperatura|sensação|sensacao|sensação térmica|sensacao termica|umidade|vento|rajada|chuva|precipita[cç][aã]o|press[aã]o|uv|iqar|aqi|hoje|amanh[aã]|manh[aã]|tarde|noite|ensolarado|sol|nublado|encoberto|chuvoso|temporal|trovoada|raio|rel[aâ]mpago|neblina|névoa|geada)",
+  "weather_temperature_pattern": "(?<!\\d)([+\\-−]?\\d{1,3})\\s*(?:°(?:\\s*(?:c|f)(?!\\p{L}))?|℃|℉)",
+  "weather_day_pattern": "(hoje|amanh[aã]|manh[aã]|tarde|noite|madrugada|agora|fim\\s+de\\s+semana|segunda|terça|ter[cç]a|quarta|quinta|sexta|s[aá]bado|domingo)",
+  "weather_condition_pattern": "(ensolarado|sol|céu\\s+limpo|ceu\\s+limpo|claro|nublado|encoberto|chuva|chuvoso|garoa|temporal|trovoada|raio|rel[aâ]mpago|neve|granizo|neblina|n[eé]voa|vento|ventania)",
+  "weather_condition_thunder_pattern": "(trovoada|trov[aã]o|raio|rel[aâ]mpago|temporal|tempestade)",
+  "weather_condition_rain_pattern": "(chuva|chuvoso|garoa|pancadas|precipita[cç][aã]o)",
+  "weather_condition_snow_pattern": "(neve|nevasca|granizo)",
+  "weather_condition_fog_pattern": "(neblina|n[eé]voa|cerra[cç][aã]o|nevoeiro)",
+  "weather_condition_wind_pattern": "(vento|ventania|rajada|ventoso)",
+  "weather_condition_sun_pattern": "(ensolarado|sol|céu\\s+limpo|ceu\\s+limpo|claro)",
+  "weather_condition_cloud_pattern": "(nublado|encoberto|nebulosidade|nuvens)",
+  "external_device_name_patterns": [
+    "(?:conectad[oa]|conectando|emparelhad[oa]|emparelhando|paread[oa]|pareando)\\s*(?:a|ao|à|com)?\\s*[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?(?=\\s|$|[,.!])",
+    "[\"«]?([\\p{L}\\p{N}][\\p{L}\\p{N} ._#\\-]{1,40})[\"»]?\\s*(?:est[aá]\\s+)?(?:conectad[oa]|conectando|emparelhad[oa]|emparelhando|paread[oa]|pareando)\\b"
+  ],
+  "external_device_generic_names": [
+    "dispositivo",
+    "dispositivos",
+    "1 dispositivo",
+    "2 dispositivos",
+    "3 dispositivos",
+    "4 dispositivos",
+    "5 dispositivos",
+    "câmera",
+    "camera",
+    "acessório",
+    "acessorio",
+    "bluetooth",
+    "usb",
+    "fone",
+    "fone de ouvido",
+    "relógio",
+    "relogio",
+    "smartwatch",
+    "pulseira",
+    "wearable",
+    "hotspot",
+    "ponto de acesso",
+    "wifi",
+    "wi-fi"
+  ],
+  "vpn_speed_pattern": "(?<!\\d)\\d{1,4}(?:[.,]\\d{1,2})?\\s*(?:[kmg]?i?b|[kmg]?b|kb|mb|gb)\\s*(?:(?:/\\s*s)|(?:/\\s*seg)|(?:/\\s*sec)|ps)\\b",
+  "vpn_context_pattern": "(\\bvpn\\b|wireguard|openvpn|hiddify|clash|v2ray|singbox|outline|amnezia|tailscale|zerotier|t[uú]nel|tunel|proxy|servidor\\s+vpn|conex[aã]o\\s+segura|conex[aã]o\\s+protegida)",
+  "vpn_package_markers": [
+    "hiddify",
+    "wireguard",
+    "openvpn",
+    "nordvpn",
+    "protonvpn",
+    "surfshark",
+    "expressvpn",
+    "outline",
+    "amnezia",
+    "clash",
+    "v2ray",
+    "hysteria",
+    "singbox",
+    "tailscale",
+    "zerotier",
+    "shadowsocks",
+    "vpn"
+  ],
+  "vpn_download_markers": [
+    "↓",
+    "dl",
+    "downlink",
+    "download",
+    "down",
+    "rx",
+    "recv",
+    "receive",
+    "incoming",
+    "inbound",
+    "ingress",
+    "entrada",
+    "recebido",
+    "receber",
+    "baixando",
+    "download"
+  ],
+  "vpn_upload_markers": [
+    "↑",
+    "ul",
+    "uplink",
+    "upload",
+    "up",
+    "tx",
+    "send",
+    "outgoing",
+    "outbound",
+    "egress",
+    "saída",
+    "saida",
+    "enviado",
+    "enviar",
+    "subindo",
+    "upload"
+  ],
+  "otp_code_patterns": [
+    "(?:\\bc[oó]digo\\b|\\botp\\b|\\btoken\\b|\\bsenha\\b|verifica[cç][aã]o|confirma[cç][aã]o|autentica[cç][aã]o|autoriza[cç][aã]o)[^\\d\\n]{0,80}(\\d(?:[\\s-]?\\d){3,7})(?!\\d)",
+    "(?<!\\S)(\\d{4,8})(?!\\d)",
+    "(?<!\\S)(\\d(?:[\\s-]?\\d){3,7})(?!\\d)",
+    "(?<!\\S)([A-Z0-9]{4,8})(?!\\w)"
+  ],
+  "order_context_hints": [
+    "pedido",
+    "entrega",
+    "delivery",
+    "corrida",
+    "viagem"
+  ],
+  "entity_token_patterns": [
+    "(?:pedido|order|corrida|viagem|entrega|protocolo)\\s*(?:#|n[ºo°]?|id|c[oó]digo|n[uú]mero)\\s*([a-zA-Z0-9-]{2,20})",
+    "(?:pedido|corrida|viagem|entrega)\\s+([a-zA-Z0-9-]*\\d[a-zA-Z0-9-]{1,19})",
+    "(?:#|n[ºo°])\\s*([a-zA-Z0-9-]{2,20})"
+  ],
+  "status_labels": {
+    "food": {
+      "pt-BR": {
+        "0": "Pago",
+        "1": "Preparando",
+        "2": "Pronto",
+        "3": "A caminho",
+        "4": "Entregue"
+      }
+    },
+    "taxi": {
+      "pt-BR": {
+        "0": "Buscando",
+        "1": "Motorista",
+        "2": "Chegando",
+        "3": "Em viagem",
+        "4": "Concluída"
+      }
+    },
+    "navigation": {
+      "pt-BR": {
+        "1": "Rota",
+        "2": "Navegação",
+        "3": "Quase lá",
+        "4": "Chegou"
+      }
+    },
+    "external_device": {
+      "pt-BR": {
+        "1": "Conectando",
+        "2": "Conectado"
+      }
+    },
+    "vpn": {
+      "pt-BR": {
+        "1": "VPN"
+      }
+    }
+  }
+}

--- a/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/LiveParserDictionary.kt
+++ b/android/app/src/main/kotlin/com/appsfolder/livebridge/liveupdate/LiveParserDictionary.kt
@@ -598,6 +598,7 @@ internal object LiveParserDictionaryLoader {
 
     private val languagePacks = listOf(
         DictionaryLanguagePack("en", "liveupdate_dictionary_en.json"),
+        DictionaryLanguagePack("pt-BR", "liveupdate_dictionary_pt-BR.json"),
         DictionaryLanguagePack("ru", "liveupdate_dictionary_ru.json"),
         DictionaryLanguagePack("zh", "liveupdate_dictionary_zh.json"),
         DictionaryLanguagePack("ko", "liveupdate_dictionary_ko.json")

--- a/lib/screens/redesign/dictionary_runtime.dart
+++ b/lib/screens/redesign/dictionary_runtime.dart
@@ -20,6 +20,11 @@ const List<DictionaryLanguageOption> lbDictionaryLanguages =
         assetFileName: 'liveupdate_dictionary_en.json',
       ),
       DictionaryLanguageOption(
+        id: 'pt-BR',
+        label: 'Português (Brasil)',
+        assetFileName: 'liveupdate_dictionary_pt-BR.json',
+      ),
+      DictionaryLanguageOption(
         id: 'ru',
         label: 'Русский',
         assetFileName: 'liveupdate_dictionary_ru.json',
@@ -146,7 +151,9 @@ const Set<String> _languageSensitiveStringKeys = <String>{
 final RegExp _hangulRegExp = RegExp(r'[\uAC00-\uD7AF\u3131-\u318E]');
 final RegExp _cjkRegExp = RegExp(r'[\u3400-\u9FFF\uF900-\uFAFF]');
 final RegExp _cyrillicRegExp = RegExp(r'[\u0400-\u04FF]');
-final RegExp _latinRegExp = RegExp(r'[A-Za-z]');
+final RegExp _latinRegExp = RegExp(
+  r'[A-Za-zÀ-ÖØ-öø-ÿ\u0100-\u017F\u0300-\u036F]',
+);
 
 List<dynamic> _scopeSmartRules(List<dynamic>? raw, String languageId) {
   if (raw == null) {
@@ -286,7 +293,7 @@ bool _matchesLanguageForLocale(String localeKey, String languageId) {
 Set<String> _detectLanguages(String raw) {
   final String value = raw.trim();
   if (value.isEmpty) {
-    return const <String>{'en', 'ru', 'zh', 'ko'};
+    return const <String>{'en', 'pt-BR', 'ru', 'zh', 'ko'};
   }
 
   final Set<String> languages = <String>{};
@@ -301,9 +308,10 @@ Set<String> _detectLanguages(String raw) {
   }
   if (_latinRegExp.hasMatch(value)) {
     languages.add('en');
+    languages.add('pt-BR');
   }
 
-  return languages.isEmpty ? const <String>{'en', 'ru', 'zh', 'ko'} : languages;
+  return languages.isEmpty ? const <String>{'en', 'pt-BR', 'ru', 'zh', 'ko'} : languages;
 }
 
 dynamic _deepCopyJsonNode(dynamic node) {


### PR DESCRIPTION
Adds Português (Brasil) support by introducing a dedicated pt-BR dictionary language file and updating Latin-script language detection to include pt-BR.

Changes included:
Added liveupdate_dictionary_lang_pt-BR.json.
Added pt-BR smart rules for food delivery, taxi, navigation, external devices, and VPN notifications.
Added pt-BR status labels for all supported rule categories.
Added pt-BR patterns for OTP detection, money context, progress percentage context, weather, navigation instructions, privacy-redacted notifications, VPN speed/context, and entity tokens.
Added Brazilian app/package hints such as iFood, Rappi, aiqfome, 99, inDrive, Waze, Google Maps, and Climatempo.
Updated Latin-script detection so pt-BR dictionaries can be considered alongside English for Latin-based notification text.